### PR TITLE
feat: simplify setup summary formatting

### DIFF
--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -62,11 +62,10 @@ def merch_tree(data: dict) -> str:
         return "—"
     lines: List[str] = []
     for mk, mi in merch.items():
-        lines.append(mi.get("name_ru", mk))
+        lines.append(f"- {mi.get('name_ru', mk)}")
         colors = list(mi.get("colors", {}).values())
-        for idx, ci in enumerate(colors):
-            branch = "└─" if idx == len(colors) - 1 else "├─"
-            lines.append(f"{branch}{ci.get('name_ru', '—')}")
+        for ci in colors:
+            lines.append(f"  - {ci.get('name_ru', '—')}")
     return "\\n".join(lines)
 
 def home_text(d: dict) -> str:
@@ -98,35 +97,32 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block = []
-    block.append("<pre>")
     block.append("<b>🎛 <i>МАСТЕР НАСТРОЙКИ</i></b>\\n")
-    block.append(f"<b>1. 🛍 Мерч</b>  <b>[{_on_off(merch_on)}]</b>")
-    block.append(f"   ├─ <b>Цвета:</b>   {'✅' if colors_ok else '❌'}")
-    block.append(f"   └─ <b>Размеры:</b> {'✅' if sizes_ok  else '❌'}\\n")
-    block.append(f"<b>2. 🔤 Буквы</b> <b>[{_on_off(feats.get('letters', False))}]</b>")
+    block.append(f"1. 🛍 Мерч [{_on_off(merch_on)}]")
+    block.append(f"   • Цвета:   {'✅' if colors_ok else '❌'}")
+    block.append(f"   • Размеры: {'✅' if sizes_ok  else '❌'}\\n")
+    block.append(f"2. 🔤 Буквы [{_on_off(feats.get('letters', False))}]")
     alph = []
     if rules.get('allow_latin'): alph.append("LAT")
     if rules.get('allow_cyrillic'): alph.append("CYR")
     alph_str = "/".join(alph) if alph else "—"
-    block.append(f"   ├─ <b>Алфавит:</b> {alph_str} ▸")
-    block.append(f"   ├─ <b>Пробел:</b> {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}")
-    block.append( "   ├─ <b>Пределы:</b>")
-    block.append(f"   │   ├─ Текст: ≤{rules.get('max_text_len','—')} симв")
-    block.append(f"   │   └─ Номер: ≤{rules.get('max_number','—')}")
-    block.append(f"   └─ <b>Палитра:</b> {(' | ').join(pal) if pal else '—'}\\n")
-    block.append(f"<b>3. 🔢 Цифры</b> <b>[{_on_off(feats.get('numbers', False))}]</b>")
-    block.append(f"   └─ <b>Соответствия:</b>")
-    block.append(f"       Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\\n")
-    block.append(f"<b>4. 🖼 Макеты</b> <b>[{_on_off(nums_set)}]</b>")
-    block.append(f"   ├─ <b>Номера:</b> {'✅' if nums_set else '❌'}")
-    block.append(f"   └─ <b>Коллажи:</b> {coll_count} {'🟢' if coll_count else '🚫'}\\n")
-    block.append(f"<b>5. 📦 Остатки</b> <b>[{_on_off(bool(inv_merch))}]</b>")
-    block.append(f"   ├─ <b>Размеры:</b> {'✅' if bool(inv_merch)   else '❌'}")
-    block.append(f"   ├─ <b>Буквы:</b>  {'✅' if bool(inv_letters) else '❌'}")
-    block.append(f"   ├─ <b>Цифры:</b>  {'✅' if bool(inv_numbers) else '❌'}")
-    block.append(f"   └─ <b>Макеты:</b> {'✅' if bool(inv_tmpls)   else '❌'}\\n")
+    block.append(f"   • Алфавит: {alph_str} ▸")
+    block.append(f"   • Пробел: {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}")
+    block.append("   • Пределы:")
+    block.append(f"     • Текст: ≤{rules.get('max_text_len','—')} симв")
+    block.append(f"     • Номер: ≤{rules.get('max_number','—')}")
+    block.append(f"   • Палитра: {(' | ').join(pal) if pal else '—'}\\n")
+    block.append(f"3. 🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
+    block.append(f"   • Соответствия: Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\\n")
+    block.append(f"4. 🖼 Макеты [{_on_off(nums_set)}]")
+    block.append(f"   • Номера: {'✅' if nums_set else '❌'}")
+    block.append(f"   • Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\\n")
+    block.append(f"5. 📦 Остатки [{_on_off(bool(inv_merch))}]")
+    block.append(f"   • Размеры: {'✅' if bool(inv_merch)   else '❌'}")
+    block.append(f"   • Буквы:  {'✅' if bool(inv_letters) else '❌'}")
+    block.append(f"   • Цифры:  {'✅' if bool(inv_numbers) else '❌'}")
+    block.append(f"   • Макеты: {'✅' if bool(inv_tmpls)   else '❌'}\\n")
     # дерево мерча
     block.append("<b>Структура мерча</b>")
     block.append(merch_tree(d))
-    block.append("</pre>")
     return "\\n".join(block)


### PR DESCRIPTION
## Summary
- show setup summary as normal HTML text instead of `<pre>` block
- replace ASCII tree with bullet list for merch structure

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68973112bb748324baeb741af6256d2a