### PR TITLE
Ensure bot outputs structured settings message

### DIFF
--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit, slugify, merch_tree
+import html
 
 DEFAULT_MERCH  = [("tshirt","Футболки"),("shopper","Шопперы"),("mug","Кружки")]
 DEFAULT_COLORS = [("white","Белый"),("black","Чёрный"),("red","Красный"),("blue","Синий"),("green","Зелёный"),("brown","Коричневый")]
@@ -10,7 +11,8 @@ ONESIZE        = ["OneSize"]
 
 def _header_with_tree(chat_id: int, title: str) -> str:
     d = WIZ[chat_id]["data"]
-    return "<pre>" + title + "\\n\\n<b>Структура</b>\\n" + (merch_tree(d) or "—") + "\\n</pre>"
+    tree = "Структура\n" + (merch_tree(d) or "—")
+    return f"{title}\n\n<pre><code>{html.escape(tree)}</code></pre>"
 
 def render_types(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})

--- a/handlers/setup/A2_Letters.py
+++ b/handlers/setup/A2_Letters.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+import html
 
 def render_letters_hub(chat_id: int):
     d = WIZ[chat_id]["data"]
@@ -14,21 +15,22 @@ def render_letters_hub(chat_id: int):
     alphabet_line = (("Латиница" if rules.get('allow_latin') else "") + (" / " if rules.get('allow_latin') and rules.get('allow_cyrillic') else "") + ("Кириллица" if rules.get('allow_cyrillic') else "")) or "—"
     space_line    = "Разрешен ✔️" if rules.get('allow_space') else "Запрещен ✖️"
 
-    text = (
-        "<pre>"
-        "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\\n\\n"
-        "<b>✨ Буквы</b>\\n"
-        f"   ├─ <b>Статус:</b> {letters_status}\\n"
-        f"   ├─ <b>Алфавит:</b> {alphabet_line} ▸ \\n"
-        f"   ├─ <b>Пробел:</b> {space_line}\\n"
-        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} симв\\n\\n"
-        "<b>✨ Цифры</b>\\n"
-        f"   ├─ <b>Статус:</b> {numbers_status}\\n"
-        f"   └─ <b>Макс. номер:</b> ≤{rules.get('max_number','—')}\\n\\n"
-        "<b>🎨 Палитра цветов текста</b>\\n"
-        f"   └─ {', '.join(pal) if pal else '—'}\\n"
-        "</pre>"
-    )
+    lines = [
+        "✨ Буквы",
+        f"   ├─ Статус: {letters_status}",
+        f"   ├─ Алфавит: {alphabet_line} ▸ ",
+        f"   ├─ Пробел: {space_line}",
+        f"   └─ Макс. длина: ≤{rules.get('max_text_len','—')} симв",
+        "",
+        "✨ Цифры",
+        f"   ├─ Статус: {numbers_status}",
+        f"   └─ Макс. номер: ≤{rules.get('max_number','—')}",
+        "",
+        "🎨 Палитра цветов текста",
+        f"   └─ {', '.join(pal) if pal else '—'}",
+    ]
+    body = html.escape("\n".join(lines))
+    text = "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\n\n<pre><code>" + body + "</code></pre>"
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton(f"Буквы: {'вкл' if feats.get('letters') else 'выкл'}", callback_data="setup:feature_toggle:letters"),
             types.InlineKeyboardButton(f"Цифры: {'вкл' if feats.get('numbers') else 'выкл'}", callback_data="setup:feature_toggle:numbers"))
@@ -45,12 +47,13 @@ def render_letters_hub(chat_id: int):
 def render_limits_progress(chat_id: int):
     d = WIZ[chat_id]["data"].setdefault("text_rules", {"allow_latin": True, "allow_cyrillic": False, "allow_space": True, "max_text_len": 12, "max_number": 99})
     st = WIZ[chat_id]["data"].setdefault("_limits", {"len_ok": bool(d.get('max_text_len')), "num_ok": bool(d.get('max_number'))})
-    text = (
-        "<pre><b>Пределы ✏️</b>\\n"
-        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})\\n"
-        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})\\n"
-        "Выберите этап или укажите по порядку.\\n</pre>"
-    )
+    lines = [
+        "Пределы ✏️",
+        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})",
+        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})",
+        "Выберите этап или укажите по порядку.",
+    ]
+    text = "<pre><code>" + html.escape("\n".join(lines)) + "</code></pre>"
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Ввести длину текста", callback_data="setup:limits_edit:text_len"),
             types.InlineKeyboardButton("2) Ввести макс. номер", callback_data="setup:limits_edit:max_num"))

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Tuple, List
 from telebot import types
 from telebot.apihelper import ApiTelegramException
 from bot import bot
+import html
 
 # Состояние мастера по chat_id
 WIZ: Dict[int, Dict[str, Any]] = {}  # {"anchor_id", "stage", "data", "_sig"}
@@ -96,37 +97,37 @@ def home_text(d: dict) -> str:
     inv_numbers = d.get("_inv_numbers", {}) if feats.get("numbers") else True
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
-    block: List[str] = []
-    block.append("<b>🎛 МАСТЕР НАСТРОЙКИ</b>\\n")
+    lines: List[str] = []
 
-    block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
-    block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
-    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\\n")
+    lines.append(f"🛍 Мерч [{_on_off(merch_on)}]")
+    lines.append(f"    ├─ Цвета: {'✅' if colors_ok else '❌'}")
+    lines.append(f"    └─ Размеры: {'✅' if sizes_ok else '❌'}\n")
 
-    block.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
+    lines.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
     alph: List[str] = []
     if rules.get('allow_latin'): alph.append("LAT")
     if rules.get('allow_cyrillic'): alph.append("CYR")
     alph_str = "/".join(alph) if alph else "—"
-    block.append(f"├─ Алфавит: {alph_str} — ▸")
-    block.append(f"├─ Пробел: {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}")
-    block.append("├─ Пределы:")
-    block.append(f"│ ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
-    block.append(f"│ └─ Номер: ≤ {rules.get('max_number', '—')}")
-    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\\n")
+    lines.append(f"    ├─ Алфавит: {alph_str} — ▸")
+    lines.append(f"    ├─ Пробел: {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}")
+    lines.append("    ├─ Пределы:")
+    lines.append(f"    │   ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
+    lines.append(f"    │   └─ Номер: ≤ {rules.get('max_number', '—')}")
+    lines.append(f"    └─ Палитра: {(' | ').join(pal) if pal else '—'}\n")
 
-    block.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
-    block.append("└─ Соответствия:")
-    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\\n")
+    lines.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
+    lines.append("    └─ Соответствия:")
+    lines.append(f"        Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\n")
 
-    block.append(f"🖼 Макеты [{_on_off(nums_set)}]")
-    block.append(f"├─ Номера: {'✅' if nums_set else '❌'}")
-    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\\n")
+    lines.append(f"🖼 Макеты [{_on_off(nums_set)}]")
+    lines.append(f"    ├─ Номера: {'✅' if nums_set else '❌'}")
+    lines.append(f"    └─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\n")
 
-    block.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
-    block.append(f"├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
-    block.append(f"├─ Буквы: {'✅' if bool(inv_letters) else '❌'}")
-    block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
-    block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
+    lines.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
+    lines.append(f"    ├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
+    lines.append(f"    ├─ Буквы: {'✅' if bool(inv_letters) else '❌'}")
+    lines.append(f"    ├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
+    lines.append(f"    └─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
 
-    return "\\n".join(block)
+    body = html.escape("\n".join(lines))
+    return "<b>🎛 МАСТЕР НАСТРОЙКИ</b>\n\n<pre><code>" + body + "</code></pre>"


### PR DESCRIPTION
## Summary
- Escape and wrap setup wizard text in `<pre><code>` blocks for consistent formatting across steps
- Preserve indentation for letters and limits configuration screens

## Testing
- `python -m py_compile handlers/setup/A1_Merch.py handlers/setup/A2_Letters.py handlers/setup/core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974080507883248fe7af0fb288f5c8