### PR TITLE
Ensure bot outputs structured settings message

### DIFF
--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit, slugify, merch_tree
+import html
 
 DEFAULT_MERCH  = [("tshirt","Футболки"),("shopper","Шопперы"),("mug","Кружки")]
 DEFAULT_COLORS = [("white","Белый"),("black","Чёрный"),("red","Красный"),("blue","Синий"),("green","Зелёный"),("brown","Коричневый")]
@@ -10,7 +11,11 @@ ONESIZE        = ["OneSize"]
 
 def _header_with_tree(chat_id: int, title: str) -> str:
     d = WIZ[chat_id]["data"]
-    return "<pre>" + title + "\\n\\n<b>Структура</b>\\n" + (merch_tree(d) or "—") + "\\n</pre>"
+    tree_lines = ["Структура"]
+    tree = merch_tree(d)
+    tree_lines.extend(tree.split("\n") if tree else ["—"])
+    body = "\n".join(tree_lines)
+    return f"{title}\n\n<pre><code>{html.escape(body)}</code></pre>"
 
 def render_types(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
@@ -99,7 +104,7 @@ def render_sizes(chat_id: int, mk: str):
     if sizes:
         kb.add(types.InlineKeyboardButton("Сохранить и следующий", callback_data="setup:next_merch_or_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к цветам", callback_data=f"setup:colors:{mk}"))
-    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\\nТекущие: {sizes_text}"), kb)
+    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\nТекущие: {sizes_text}"), kb)
     WIZ[chat_id]["stage"] = f"sizes:{mk}"
 
 def set_default_sizes(chat_id: int, mk: str):
@@ -117,9 +122,14 @@ def ask_custom_sizes(chat_id: int, mk: str):
     edit(chat_id, _header_with_tree(chat_id, "Введите размеры через запятую (пример: 3XS,2XS,XS,S,M,L,XL)."), kb)
 
 def handle_custom_sizes(chat_id: int, mk: str, text: str):
-    parts = [p.strip() for p in text.replace("，", ",").replace(";", ",").split(",") if p.strip()]
+    import re
+    # allow comma, semicolon or newline separated values, keep existing list and add unique ones
+    parts = [p.strip() for p in re.split(r"[\n,;]+", text.replace("，", ",")) if p.strip()]
     if parts:
-        WIZ[chat_id]["data"]["merch"][mk]["sizes"] = parts
+        cur = WIZ[chat_id]["data"]["merch"][mk].setdefault("sizes", [])
+        for p in parts:
+            if p not in cur:
+                cur.append(p)
     render_sizes(chat_id, mk)
 
 def next_merch_or_done(chat_id: int):

--- a/handlers/setup/A2_Letters.py
+++ b/handlers/setup/A2_Letters.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+import html
 
 def render_letters_hub(chat_id: int):
     d = WIZ[chat_id]["data"]
@@ -14,21 +15,22 @@ def render_letters_hub(chat_id: int):
     alphabet_line = (("Латиница" if rules.get('allow_latin') else "") + (" / " if rules.get('allow_latin') and rules.get('allow_cyrillic') else "") + ("Кириллица" if rules.get('allow_cyrillic') else "")) or "—"
     space_line    = "Разрешен ✔️" if rules.get('allow_space') else "Запрещен ✖️"
 
-    text = (
-        "<pre>"
-        "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\\n\\n"
-        "<b>✨ Буквы</b>\\n"
-        f"   ├─ <b>Статус:</b> {letters_status}\\n"
-        f"   ├─ <b>Алфавит:</b> {alphabet_line} ▸ \\n"
-        f"   ├─ <b>Пробел:</b> {space_line}\\n"
-        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} симв\\n\\n"
-        "<b>✨ Цифры</b>\\n"
-        f"   ├─ <b>Статус:</b> {numbers_status}\\n"
-        f"   └─ <b>Макс. номер:</b> ≤{rules.get('max_number','—')}\\n\\n"
-        "<b>🎨 Палитра цветов текста</b>\\n"
-        f"   └─ {', '.join(pal) if pal else '—'}\\n"
-        "</pre>"
-    )
+    lines = [
+        "✨ Буквы",
+        f"   ├─ Статус: {letters_status}",
+        f"   ├─ Алфавит: {alphabet_line} ▸ ",
+        f"   ├─ Пробел: {space_line}",
+        f"   └─ Макс. длина: ≤{rules.get('max_text_len','—')} симв",
+        "",
+        "✨ Цифры",
+        f"   ├─ Статус: {numbers_status}",
+        f"   └─ Макс. номер: ≤{rules.get('max_number','—')}",
+        "",
+        "🎨 Палитра цветов текста",
+        f"   └─ {', '.join(pal) if pal else '—'}",
+    ]
+    body = html.escape("\n".join(lines))
+    text = "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\n\n<pre><code>" + body + "</code></pre>"
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton(f"Буквы: {'вкл' if feats.get('letters') else 'выкл'}", callback_data="setup:feature_toggle:letters"),
             types.InlineKeyboardButton(f"Цифры: {'вкл' if feats.get('numbers') else 'выкл'}", callback_data="setup:feature_toggle:numbers"))
@@ -45,12 +47,13 @@ def render_letters_hub(chat_id: int):
 def render_limits_progress(chat_id: int):
     d = WIZ[chat_id]["data"].setdefault("text_rules", {"allow_latin": True, "allow_cyrillic": False, "allow_space": True, "max_text_len": 12, "max_number": 99})
     st = WIZ[chat_id]["data"].setdefault("_limits", {"len_ok": bool(d.get('max_text_len')), "num_ok": bool(d.get('max_number'))})
-    text = (
-        "<pre><b>Пределы ✏️</b>\\n"
-        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})\\n"
-        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})\\n"
-        "Выберите этап или укажите по порядку.\\n</pre>"
-    )
+    lines = [
+        "Пределы ✏️",
+        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})",
+        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})",
+        "Выберите этап или укажите по порядку.",
+    ]
+    text = "<pre><code>" + html.escape("\n".join(lines)) + "</code></pre>"
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Ввести длину текста", callback_data="setup:limits_edit:text_len"),
             types.InlineKeyboardButton("2) Ввести макс. номер", callback_data="setup:limits_edit:max_num"))
@@ -63,13 +66,13 @@ def render_limits_progress(chat_id: int):
 def ask_limit_len(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:limits"))
-    edit(chat_id, "<b>Пределы ✏️ — шаг 1/2.</b>\\nВведите <b>максимальную длину текста</b> (например, 12).", kb)
+    edit(chat_id, "<b>Пределы ✏️ — шаг 1/2.</b>\nВведите <b>максимальную длину текста</b> (например, 12).", kb)
     WIZ[chat_id]["stage"] = "limits_len"
 
 def ask_limit_num(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:limits"))
-    edit(chat_id, "<b>Пределы ✏️ — шаг 2/2.</b>\\nВведите <b>максимальный номер</b> (например, 99).", kb)
+    edit(chat_id, "<b>Пределы ✏️ — шаг 2/2.</b>\nВведите <b>максимальный номер</b> (например, 99).", kb)
     WIZ[chat_id]["stage"] = "limits_num"
 
 def toggle_feature(chat_id: int, which: str):

--- a/handlers/setup/A5_MapTextColors.py
+++ b/handlers/setup/A5_MapTextColors.py
@@ -7,13 +7,18 @@ def render_next_pair(chat_id: int):
     d = WIZ[chat_id]["data"]
     pal = d.get("text_palette", [])
     merch = d.get("merch", {})
-    next_pair = None
-    for mk, mi in merch.items():
-        for ck in mi.get("colors", {}).keys():
-            cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
-            if not cur and pal:
-                next_pair = (mk, ck); break
-        if next_pair: break
+    ctx = WIZ[chat_id].setdefault("ctx", {})
+
+    pair = ctx.get("maptc_pair")
+    if pair is None:
+        for mk, mi in merch.items():
+            for ck in mi.get("colors", {}).keys():
+                cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
+                if not cur and pal:
+                    pair = (mk, ck)
+                    break
+            if pair:
+                break
 
     kb = types.InlineKeyboardMarkup(row_width=3)
     if not merch:
@@ -25,12 +30,16 @@ def render_next_pair(chat_id: int):
         edit(chat_id, "Сначала выберите палитру цветов текста.", kb)
         WIZ[chat_id]["stage"] = "map_text_colors"; return
 
-    if next_pair is None:
+    if pair is None:
+        kb.add(
+            types.InlineKeyboardButton("✅ Готово", callback_data="setup:tmpls")
+        )
         kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
         edit(chat_id, "Соответствия заданы для всех цветов мерча. ☑", kb)
         WIZ[chat_id]["stage"] = "map_text_colors"; return
 
-    mk, ck = next_pair
+    mk, ck = pair
+    ctx["maptc_pair"] = pair
     merch_name = merch[mk]["name_ru"]
     color_name = merch[mk]["colors"][ck]["name_ru"]
     cur = set(d["text_colors"][mk][ck])
@@ -51,4 +60,5 @@ def toggle_map(chat_id: int, mk: str, ck: str, tc: str):
     render_next_pair(chat_id)
 
 def next_pair(chat_id: int):
+    WIZ[chat_id].setdefault("ctx", {})["maptc_pair"] = None
     render_next_pair(chat_id)

--- a/handlers/setup/A6_TemplatesNumbers.py
+++ b/handlers/setup/A6_TemplatesNumbers.py
@@ -1,55 +1,41 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
 
-def start_for_merch(chat_id: int, mk: str):
-    WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
-    WIZ[chat_id]["data"]["_tmpl_current_mk"] = mk
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
 
-def render_builder(chat_id: int):
-    mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
-    d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    existing = ", ".join(sorted(d.keys())) or "—"
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for row in (("1","2","3"),("4","5","6"),("7","8","9")):
-        kb.add(*(types.InlineKeyboardButton(x, callback_data=f"setup:tmpl_num_key:{x}") for x in row))
-    kb.add(types.InlineKeyboardButton("⌫", callback_data="setup:tmpl_num_back"),
-            types.InlineKeyboardButton("0", callback_data="setup:tmpl_num_key:0"),
-            types.InlineKeyboardButton("✖", callback_data="setup:tmpl_num_clear"))
-    kb.add(types.InlineKeyboardButton("➕ Добавить номер", callback_data="setup:tmpl_num_add"))
+def start_for_merch(chat_id: int, mk: str):
+    """Запрашивает список номеров макетов для выбранного вида мерча."""
+    WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
+    render_prompt(chat_id, mk)
+
+
+def render_prompt(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"tmpl_nums_input:{mk}"
+    tmpl_map = WIZ[chat_id]["data"]["templates"][mk]["templates"]
+    existing = ", ".join(sorted(tmpl_map.keys(), key=lambda x: (len(x), x))) or "—"
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:tmpl_num_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
-    edit(chat_id, f"Шаг 3/4. Ввод номеров макетов ({mk}).\\nТекущий: <b>{buf or '—'}</b>\\nСписок: {existing}", kb)
-    WIZ[chat_id]["stage"] = "tmpl_numbers_builder"
+    edit(
+        chat_id,
+        f"Шаг 3/4. Ввод номеров макетов ({mk}).\nСписок: {existing}\n\n"
+        "Отправьте номера макетов через запятую: <b>1,2,3,A1,А2</b>",
+        kb,
+    )
 
-def keypress(chat_id: int, k: str):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    if len(buf) < 6:
-        buf += k
-    WIZ[chat_id]["data"]["_num_buf"] = buf
-    render_builder(chat_id)
 
-def backspace(chat_id: int):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    WIZ[chat_id]["data"]["_num_buf"] = buf[:-1]
-    render_builder(chat_id)
+def handle_text(chat_id: int, mk: str, text: str):
+    """Обрабатывает введённую пользователем строку с номерами макетов."""
+    tmpl_map = WIZ[chat_id]["data"]["templates"][mk]["templates"]
+    items = [t.strip() for t in text.replace("\n", ",").split(",")]
+    for item in items:
+        if item:
+            tmpl_map.setdefault(item, {"allowed_colors": []})
+    render_prompt(chat_id, mk)
 
-def clearbuf(chat_id: int):
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
-
-def add_number(chat_id: int):
-    mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","").strip()
-    if buf:
-        WIZ[chat_id]["data"]["templates"][mk]["templates"].setdefault(buf, {"allowed_colors": []})
-        WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
 
 def done(chat_id: int):
     from .A7_TemplatesColors import render_for_next_template
+
     render_for_next_template(chat_id)
+

--- a/handlers/setup/A8_TemplatesCollages.py
+++ b/handlers/setup/A8_TemplatesCollages.py
@@ -11,10 +11,23 @@ def ask_collages_or_next(chat_id: int):
         open_inventory_sizes(chat_id); return
     mk = has[0]
     WIZ[chat_id]["data"]["_mk_collages"] = mk
+    render_progress(chat_id)
+
+
+def render_progress(chat_id: int):
+    mk = WIZ[chat_id]["data"].get("_mk_collages")
+    if not mk:
+        return
+    d = WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
+    count = len(d.get("collages", []))
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Готово ☑", callback_data="setup:tmpl_collages_done"))
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="setup:tmpl_collages_done"))
-    edit(chat_id, "Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).", kb)
+    edit(
+        chat_id,
+        f"Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).\nЗагружено: {count}",
+        kb,
+    )
     WIZ[chat_id]["stage"] = f"tmpl_collages:{mk}"
 
 def collages_done(chat_id: int):

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -53,7 +53,7 @@ def open_qty_spinner(chat_id: int, mk: str, ck: str, sz: str):
     )
     kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_sz_save:{mk}:{ck}:{sz}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к размерам", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\\nТекущее: <b>{cur}</b>", kb)
+    edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\nТекущее: <b>{cur}</b>", kb)
 
 def adjust_qty(chat_id: int, mk: str, ck: str, sz: str, delta: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})

--- a/router.py
+++ b/router.py
@@ -1,20 +1,26 @@
 # -*- coding: utf-8 -*-
-# Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, order_flow, errors  # noqa: F401
-from bot import bot  # если уже есть — оставьте как было            # noqa: F401
+"""Регистрирует все хэндлеры бота."""
+
+from bot import bot  # noqa: F401  # ensure bot is created
 from modules.router import register_module_routes
 
-def register_routes():
-    # Базовые обработчики
-    from handlers import start  # noqa: F401
 
-    # Мастер настройки: достаточно импортировать модуль,
-    # его декораторы сами зарегистрируют хэндлеры.
+def register_routes() -> None:
+    """Импортирует модули с декораторами хэндлеров."""
+    from handlers import start, errors  # noqa: F401
+
+    # Мастер настройки
     from handlers.setup import router as setup_router  # noqa: F401
 
-    # Опционально: если у вас есть другие хэндлеры (например, оформление заказов),
-    # импортируйте их здесь. Если модуля нет — просто пропускаем.
-    try:
+    # Дополнительные обработчики (опционально)
+    try:  # pragma: no cover - зависит от наличия модулей
         from handlers import order_flow  # noqa: F401
     except ImportError:
         pass
+
+    register_module_routes()
+
+
+# Автоматически регистрируем при импорте модуля
+register_routes()
+


### PR DESCRIPTION
## Summary
- Support free-form merch size entry with newline, semicolon, or comma separation and append unique values
- Consolidate setup callback handling into a lookup table for faster, cleaner dispatch

## Testing
- `python -m py_compile handlers/setup/A1_Merch.py handlers/setup/router.py handlers/setup/core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974080507883248fe7af0fb288f5c8