### PR TITLE
Fix text color mapping selection

### DIFF
--- a/handlers/setup/A2_Letters.py
+++ b/handlers/setup/A2_Letters.py
@@ -16,17 +16,17 @@ def render_letters_hub(chat_id: int):
 
     text = (
         "<pre>"
-        "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\\n\\n"
-        "<b>✨ Буквы</b>\\n"
-        f"   ├─ <b>Статус:</b> {letters_status}\\n"
-        f"   ├─ <b>Алфавит:</b> {alphabet_line} ▸ \\n"
-        f"   ├─ <b>Пробел:</b> {space_line}\\n"
-        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} симв\\n\\n"
-        "<b>✨ Цифры</b>\\n"
-        f"   ├─ <b>Статус:</b> {numbers_status}\\n"
-        f"   └─ <b>Макс. номер:</b> ≤{rules.get('max_number','—')}\\n\\n"
-        "<b>🎨 Палитра цветов текста</b>\\n"
-        f"   └─ {', '.join(pal) if pal else '—'}\\n"
+        "<b>🔤 ШАГ 2/4: НАСТРОЙКА БУКВ И ЦИФР 🔢</b>\n\n"
+        "<b>✨ Буквы</b>\n"
+        f"   ├─ <b>Статус:</b> {letters_status}\n"
+        f"   ├─ <b>Алфавит:</b> {alphabet_line} ▸ \n"
+        f"   ├─ <b>Пробел:</b> {space_line}\n"
+        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} симв\n\n"
+        "<b>✨ Цифры</b>\n"
+        f"   ├─ <b>Статус:</b> {numbers_status}\n"
+        f"   └─ <b>Макс. номер:</b> ≤{rules.get('max_number','—')}\n\n"
+        "<b>🎨 Палитра цветов текста</b>\n"
+        f"   └─ {', '.join(pal) if pal else '—'}\n"
         "</pre>"
     )
     kb = types.InlineKeyboardMarkup(row_width=2)
@@ -46,10 +46,10 @@ def render_limits_progress(chat_id: int):
     d = WIZ[chat_id]["data"].setdefault("text_rules", {"allow_latin": True, "allow_cyrillic": False, "allow_space": True, "max_text_len": 12, "max_number": 99})
     st = WIZ[chat_id]["data"].setdefault("_limits", {"len_ok": bool(d.get('max_text_len')), "num_ok": bool(d.get('max_number'))})
     text = (
-        "<pre><b>Пределы ✏️</b>\\n"
-        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})\\n"
-        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})\\n"
-        "Выберите этап или укажите по порядку.\\n</pre>"
+        "<pre><b>Пределы ✏️</b>\n"
+        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})\n"
+        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})\n"
+        "Выберите этап или укажите по порядку.\n</pre>"
     )
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Ввести длину текста", callback_data="setup:limits_edit:text_len"),
@@ -63,13 +63,13 @@ def render_limits_progress(chat_id: int):
 def ask_limit_len(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:limits"))
-    edit(chat_id, "<b>Пределы ✏️ — шаг 1/2.</b>\\nВведите <b>максимальную длину текста</b> (например, 12).", kb)
+    edit(chat_id, "<b>Пределы ✏️ — шаг 1/2.</b>\nВведите <b>максимальную длину текста</b> (например, 12).", kb)
     WIZ[chat_id]["stage"] = "limits_len"
 
 def ask_limit_num(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:limits"))
-    edit(chat_id, "<b>Пределы ✏️ — шаг 2/2.</b>\\nВведите <b>максимальный номер</b> (например, 99).", kb)
+    edit(chat_id, "<b>Пределы ✏️ — шаг 2/2.</b>\nВведите <b>максимальный номер</b> (например, 99).", kb)
     WIZ[chat_id]["stage"] = "limits_num"
 
 def toggle_feature(chat_id: int, which: str):

--- a/handlers/setup/A5_MapTextColors.py
+++ b/handlers/setup/A5_MapTextColors.py
@@ -3,52 +3,73 @@
 from telebot import types
 from .core import WIZ, edit
 
-def render_next_pair(chat_id: int):
+
+def render_pair(chat_id: int, mk: str, ck: str) -> None:
+    """Show palette selection for a concrete merch/color pair."""
     d = WIZ[chat_id]["data"]
     pal = d.get("text_palette", [])
     merch = d.get("merch", {})
-    next_pair = None
-    for mk, mi in merch.items():
-        for ck in mi.get("colors", {}).keys():
-            cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
-            if not cur and pal:
-                next_pair = (mk, ck); break
-        if next_pair: break
-
     kb = types.InlineKeyboardMarkup(row_width=3)
+
+    cur = set(d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, []))
+    for tc in pal:
+        mark = "✓" if tc in cur else "·"
+        kb.add(
+            types.InlineKeyboardButton(
+                f"{tc} {mark}", callback_data=f"setup:maptc_toggle:{mk}:{ck}:{tc}"
+            )
+        )
+    kb.add(types.InlineKeyboardButton("Далее →", callback_data="setup:maptc_next"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
+
+    merch_name = merch[mk]["name_ru"]
+    color_name = merch[mk]["colors"][ck]["name_ru"]
+    edit(
+        chat_id,
+        f"Шаг 2.1/4. {merch_name} / {color_name}: выберите допустимые <b>цвета букв/цифр</b> (можно несколько).",
+        kb,
+    )
+    WIZ[chat_id]["stage"] = "map_text_colors"
+
+
+def render_next_pair(chat_id: int) -> None:
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    merch = d.get("merch", {})
+    kb = types.InlineKeyboardMarkup(row_width=3)
+
     if not merch:
         kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
         edit(chat_id, "Сначала добавьте мерч и цвета.", kb)
-        WIZ[chat_id]["stage"] = "map_text_colors"; return
+        WIZ[chat_id]["stage"] = "map_text_colors"
+        return
     if not pal:
         kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
         edit(chat_id, "Сначала выберите палитру цветов текста.", kb)
-        WIZ[chat_id]["stage"] = "map_text_colors"; return
+        WIZ[chat_id]["stage"] = "map_text_colors"
+        return
 
-    if next_pair is None:
-        kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
-        edit(chat_id, "Соответствия заданы для всех цветов мерча. ☑", kb)
-        WIZ[chat_id]["stage"] = "map_text_colors"; return
+    for mk, mi in merch.items():
+        for ck in mi.get("colors", {}):
+            cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
+            if not cur and pal:
+                render_pair(chat_id, mk, ck)
+                return
 
-    mk, ck = next_pair
-    merch_name = merch[mk]["name_ru"]
-    color_name = merch[mk]["colors"][ck]["name_ru"]
-    cur = set(d["text_colors"][mk][ck])
-    for tc in pal:
-        mark = "✓" if tc in cur else "·"
-        kb.add(types.InlineKeyboardButton(f"{tc} {mark}", callback_data=f"setup:maptc_toggle:{mk}:{ck}:{tc}"))
-    kb.add(types.InlineKeyboardButton("Далее →", callback_data="setup:maptc_next"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
-    edit(chat_id, f"Шаг 2.1/4. {merch_name} / {color_name}: выберите допустимые <b>цвета букв/цифр</b> (можно несколько).", kb)
+    edit(chat_id, "Соответствия заданы для всех цветов мерча. ☑", kb)
     WIZ[chat_id]["stage"] = "map_text_colors"
 
-def toggle_map(chat_id: int, mk: str, ck: str, tc: str):
-    d = WIZ[chat_id]["data"].setdefault("text_colors", {})
-    d.setdefault(mk, {})
-    cur = d[mk].setdefault(ck, [])
-    if tc in cur: cur.remove(tc)
-    else: cur.append(tc)
-    render_next_pair(chat_id)
 
-def next_pair(chat_id: int):
+def toggle_map(chat_id: int, mk: str, ck: str, tc: str) -> None:
+    d = WIZ[chat_id]["data"].setdefault("text_colors", {})
+    cur = d.setdefault(mk, {}).setdefault(ck, [])
+    if tc in cur:
+        cur.remove(tc)
+    else:
+        cur.append(tc)
+    render_pair(chat_id, mk, ck)
+
+
+def next_pair(chat_id: int) -> None:
     render_next_pair(chat_id)

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -31,7 +31,7 @@ def open_sizes(chat_id: int, mk: str, ck: str):
         kb.add(types.InlineKeyboardButton(f"{sz}: {qty}", callback_data=f"setup:inv_sz_qty:{mk}:{ck}:{sz}"))
     kb.add(types.InlineKeyboardButton("➕ Применить ко всем размерам", callback_data=f"setup:inv_sz_apply_all:{mk}:{ck}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_colors:{mk}"))
-    edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}/{WIZ[chat_id]['data']['merch'][mk]['colors'][ck]['name_ru']}</b> — выберите размер.", kb)
+    edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}/{WIZ[chat_id]['data']['merch'][mk]['colors'][ck]['name_ru']}</b> — выберите размер или задайте число для всех.", kb)
 
 def open_qty_spinner(chat_id: int, mk: str, ck: str, sz: str):
     WIZ[chat_id]["stage"] = f"inv_sz_qty:{mk}:{ck}:{sz}"
@@ -53,7 +53,7 @@ def open_qty_spinner(chat_id: int, mk: str, ck: str, sz: str):
     )
     kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_sz_save:{mk}:{ck}:{sz}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к размерам", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\\nТекущее: <b>{cur}</b>", kb)
+    edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\nТекущее: <b>{cur}</b>", kb)
 
 def adjust_qty(chat_id: int, mk: str, ck: str, sz: str, delta: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
@@ -83,5 +83,6 @@ def set_all_sizes(chat_id: int, mk: str, ck: str, val: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
     sizes = WIZ[chat_id]["data"]["merch"][mk]["sizes"]
     for sz in sizes:
-        inv[sz] = val
+        if inv.get(sz, 0) == 0:
+            inv[sz] = val
     open_sizes(chat_id, mk, ck)


### PR DESCRIPTION
## Summary
- allow selecting multiple text colors per merch/color pair without jumping ahead
- keep mapping stage stable by re-rendering current pair after each toggle
- show letters/numbers setup with proper multiline formatting
- apply default inventory quantity only to unset sizes so custom values remain

## Testing
- `python -m py_compile handlers/setup/A2_Letters.py handlers/setup/A9_InventorySizes.py`


------
https://chatgpt.com/codex/tasks/task_e_689831cbeb548324a69e1b7480da7006