### PR TITLE
Improve setup wizard layout and chat binding

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.settings import save_admin_bind
+
+@bot.message_handler(commands=["bind_here"])
+def bind_here_cmd(message: types.Message):
+    thread_id = getattr(message, "message_thread_id", None)
+    save_admin_bind(message.chat.id, thread_id)
+    bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/order_flow.py
+++ b/handlers/order_flow.py
@@ -9,19 +9,16 @@ from services.inventory import (
     get_merch_inv, get_letters_inv, get_numbers_inv, get_templates_inv,
     dec_size, dec_letter, dec_number, dec_template
 )
-from repositories.files import load_json, save_json
 from services.validators import validate_text, validate_number
 from utils.tg import safe_delete, safe_edit_message
 
 # Временные заказы (по chat_id)
 ORD: dict[int, dict] = {}
 
-ADMIN_BIND_FILE = "admin_chat.json"
-
 def _admin_target():
-    b = load_json(ADMIN_BIND_FILE)
-    if b:
-        return b.get("chat_id"), b.get("thread_id")
+    chat_id, thread_id = get_admin_bind()
+    if chat_id:
+        return chat_id, thread_id
     return getattr(config, "ADMIN_CHAT_ID", None), None
 
 def _send_to_admin_or_warn(user_chat_id: int, text: str) -> None:

--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -10,7 +10,8 @@ ONESIZE        = ["OneSize"]
 
 def _header_with_tree(chat_id: int, title: str) -> str:
     d = WIZ[chat_id]["data"]
-    return "<pre>" + title + "\\n\\n<b>Структура</b>\\n" + (merch_tree(d) or "—") + "\\n</pre>"
+    tree = merch_tree(d)
+    return f"<b>{title}</b>\\n<pre>Структура\\n{tree}\\n</pre>"
 
 def render_types(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
@@ -99,6 +100,7 @@ def render_sizes(chat_id: int, mk: str):
     if sizes:
         kb.add(types.InlineKeyboardButton("Сохранить и следующий", callback_data="setup:next_merch_or_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к цветам", callback_data=f"setup:colors:{mk}"))
+    kb.add(types.InlineKeyboardButton("↩️ К видам мерча", callback_data="setup:merch"))
     edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\\nТекущие: {sizes_text}"), kb)
     WIZ[chat_id]["stage"] = f"sizes:{mk}"
 

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -97,8 +97,6 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block: List[str] = []
-    block.append("<b>🎛 МАСТЕР НАСТРОЙКИ</b>\\n")
-
     block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
     block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
     block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\\n")
@@ -129,4 +127,5 @@ def home_text(d: dict) -> str:
     block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
     block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
 
-    return "\\n".join(block)
+    body = "\\n".join(block)
+    return f"<b>🎛 МАСТЕР НАСТРОЙКИ</b>\\n<pre>{body}</pre>"

--- a/repositories/files.py
+++ b/repositories/files.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
-import os, json
+"""Utility helpers for persisting small JSON files.
+
+The previous implementation wrote directly to the destination path which
+could lead to partially written files if the process crashed mid-write. In
+addition, JSON parsing errors were silently swallowed which made diagnosing
+corrupted files difficult.  This module now writes files atomically and
+logs any I/O or JSON errors to aid debugging and improve reliability.
+"""
+
+import json
+import logging
+import os
+import tempfile
 from typing import Any, Dict
+
 import config
+
+log = logging.getLogger(__name__)
 
 def _ensure_dir(path: str) -> None:
     if not os.path.exists(path):
@@ -14,6 +28,14 @@ def _path(filename: str) -> str:
     return os.path.join(config.JSON_DIR, filename)
 
 def load_json(filename: str) -> Dict[str, Any]:
+    """Load JSON data from *filename*.
+
+    Any :class:`OSError` or :class:`json.JSONDecodeError` is logged and an
+    empty dictionary is returned instead of propagating the exception. This
+    mirrors the previous behaviour while providing insight into what went
+    wrong.
+    """
+
     path = _path(filename)
     if not os.path.exists(path):
         return {}
@@ -21,11 +43,34 @@ def load_json(filename: str) -> Dict[str, Any]:
         with open(path, "r", encoding="utf-8") as f:
             text = f.read().strip()
             return json.loads(text) if text else {}
-    except Exception:
+    except (OSError, json.JSONDecodeError) as err:
+        log.warning("Failed to load JSON from %s: %s", path, err)
         return {}
 
 def save_json(filename: str, data: Dict[str, Any]) -> None:
+    """Persist *data* to *filename* atomically.
+
+    Writing is performed to a temporary file which is then moved into place.
+    This prevents partially written files if the process crashes during
+    serialisation. Any :class:`OSError` encountered is logged and re-raised
+    so callers can react appropriately.
+    """
+
     path = _path(filename)
-    _ensure_dir(os.path.dirname(path))
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    directory = os.path.dirname(path)
+    _ensure_dir(directory)
+
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=os.path.basename(path))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(data, tmp_file, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        log.warning("Failed to write JSON to %s: %s", path, err)
+        raise
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass

--- a/router.py
+++ b/router.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, order_flow, errors  # noqa: F401
+from handlers import start, bind, order_flow, errors  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 
 def register_routes():
     # Базовые обработчики
-    from handlers import start  # noqa: F401
+    from handlers import start, bind  # noqa: F401
 
     # Мастер настройки: достаточно импортировать модуль,
     # его декораторы сами зарегистрируют хэндлеры.


### PR DESCRIPTION
## Summary
- preserve master setup and merch screens with `<pre>` blocks for stable tree-style layout
- allow returning to merch type list from size entry and add `/bind_here` command to save admin chat
- route all admin notifications through stored chat binding

## Testing
- `python -m pytest`
- `python -m py_compile handlers/setup/core.py handlers/setup/A1_Merch.py handlers/order_flow.py handlers/bind.py router.py`


------
https://chatgpt.com/codex/tasks/task_e_6898470b11ec83248363957963ba1ad3