### PR TITLE
Improve setup wizard layout, chat binding, and inventory

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.settings import save_admin_bind
+
+@bot.message_handler(commands=["bind_here"])
+def bind_here_cmd(message: types.Message):
+    thread_id = getattr(message, "message_thread_id", None)
+    save_admin_bind(message.chat.id, thread_id)
+    bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/order_flow.py
+++ b/handlers/order_flow.py
@@ -9,19 +9,16 @@ from services.inventory import (
     get_merch_inv, get_letters_inv, get_numbers_inv, get_templates_inv,
     dec_size, dec_letter, dec_number, dec_template
 )
-from repositories.files import load_json, save_json
 from services.validators import validate_text, validate_number
 from utils.tg import safe_delete, safe_edit_message
 
 # Временные заказы (по chat_id)
 ORD: dict[int, dict] = {}
 
-ADMIN_BIND_FILE = "admin_chat.json"
-
 def _admin_target():
-    b = load_json(ADMIN_BIND_FILE)
-    if b:
-        return b.get("chat_id"), b.get("thread_id")
+    chat_id, thread_id = get_admin_bind()
+    if chat_id:
+        return chat_id, thread_id
     return getattr(config, "ADMIN_CHAT_ID", None), None
 
 def _send_to_admin_or_warn(user_chat_id: int, text: str) -> None:

--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -10,7 +10,8 @@ ONESIZE        = ["OneSize"]
 
 def _header_with_tree(chat_id: int, title: str) -> str:
     d = WIZ[chat_id]["data"]
-    return "<pre>" + title + "\\n\\n<b>Структура</b>\\n" + (merch_tree(d) or "—") + "\\n</pre>"
+    tree = merch_tree(d)
+    return f"<b>{title}</b>\n<pre>Структура\n{tree}\n</pre>"
 
 def render_types(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
@@ -99,7 +100,8 @@ def render_sizes(chat_id: int, mk: str):
     if sizes:
         kb.add(types.InlineKeyboardButton("Сохранить и следующий", callback_data="setup:next_merch_or_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к цветам", callback_data=f"setup:colors:{mk}"))
-    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\\nТекущие: {sizes_text}"), kb)
+    kb.add(types.InlineKeyboardButton("↩️ К видам мерча", callback_data="setup:merch"))
+    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\nТекущие: {sizes_text}"), kb)
     WIZ[chat_id]["stage"] = f"sizes:{mk}"
 
 def set_default_sizes(chat_id: int, mk: str):

--- a/handlers/setup/A5_MapTextColors.py
+++ b/handlers/setup/A5_MapTextColors.py
@@ -31,6 +31,10 @@ def render_pair(chat_id: int, mk: str, ck: str) -> None:
     )
     WIZ[chat_id]["stage"] = "map_text_colors"
 
+    # mark this pair as reviewed under current palette size
+    seen = d.setdefault("_maptc_seen", {}).setdefault(mk, {})
+    seen[ck] = len(pal)
+
 
 def render_next_pair(chat_id: int) -> None:
     d = WIZ[chat_id]["data"]
@@ -49,9 +53,13 @@ def render_next_pair(chat_id: int) -> None:
         WIZ[chat_id]["stage"] = "map_text_colors"
         return
 
+    seen = d.setdefault("_maptc_seen", {})
     for mk, mi in merch.items():
         for ck in mi.get("colors", {}):
             cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
+            if seen.get(mk, {}).get(ck) != len(pal):
+                render_pair(chat_id, mk, ck)
+                return
             if not cur and pal:
                 render_pair(chat_id, mk, ck)
                 return

--- a/handlers/setup/A6_TemplatesNumbers.py
+++ b/handlers/setup/A6_TemplatesNumbers.py
@@ -1,54 +1,41 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
 
-def start_for_merch(chat_id: int, mk: str):
-    WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
-    WIZ[chat_id]["data"]["_tmpl_current_mk"] = mk
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
 
-def render_builder(chat_id: int):
+def start_for_merch(chat_id: int, mk: str):
+    data = WIZ[chat_id]["data"].setdefault("templates", {})
+    data.setdefault(mk, {"templates": {}, "collages": []})
+    WIZ[chat_id]["data"]["_tmpl_current_mk"] = mk
+    render_prompt(chat_id)
+
+
+def render_prompt(chat_id: int):
     mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
     d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
     existing = ", ".join(sorted(d.keys())) or "—"
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for row in (("1","2","3"),("4","5","6"),("7","8","9")):
-        kb.add(*(types.InlineKeyboardButton(x, callback_data=f"setup:tmpl_num_key:{x}") for x in row))
-    kb.add(types.InlineKeyboardButton("⌫", callback_data="setup:tmpl_num_back"),
-            types.InlineKeyboardButton("0", callback_data="setup:tmpl_num_key:0"),
-            types.InlineKeyboardButton("✖", callback_data="setup:tmpl_num_clear"))
-    kb.add(types.InlineKeyboardButton("➕ Добавить номер", callback_data="setup:tmpl_num_add"))
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:tmpl_num_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
-    edit(chat_id, f"Шаг 3/4. Ввод номеров макетов ({mk}).\\nТекущий: <b>{buf or '—'}</b>\\nСписок: {existing}", kb)
-    WIZ[chat_id]["stage"] = "tmpl_numbers_builder"
+    edit(chat_id,
+         f"Шаг 3/4. Введите номера макетов ({mk}) через запятую.\nСписок: {existing}",
+         kb)
+    WIZ[chat_id]["stage"] = "tmpl_nums_enter"
 
-def keypress(chat_id: int, k: str):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    if len(buf) < 6:
-        buf += k
-    WIZ[chat_id]["data"]["_num_buf"] = buf
-    render_builder(chat_id)
 
-def backspace(chat_id: int):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    WIZ[chat_id]["data"]["_num_buf"] = buf[:-1]
-    render_builder(chat_id)
-
-def clearbuf(chat_id: int):
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
-
-def add_number(chat_id: int):
+def handle_input(chat_id: int, text: str):
+    import re
     mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","").strip()
-    if buf:
-        WIZ[chat_id]["data"]["templates"][mk]["templates"].setdefault(buf, {"allowed_colors": []})
-        WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
+    d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
+    parts = [p.strip() for p in text.replace("\n", ",").split(",")]
+    for p in parts:
+        if not p:
+            continue
+        token = p.upper()
+        if len(token) <= 6 and re.fullmatch(r"[0-9A-ZА-Я]+", token):
+            d.setdefault(token, {"allowed_colors": []})
+    render_prompt(chat_id)
+
 
 def done(chat_id: int):
     from .A7_TemplatesColors import render_for_next_template

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -9,7 +9,7 @@ def open_inventory_sizes(chat_id: int):
     kb = types.InlineKeyboardMarkup(row_width=2)
     for mk, info in d.get("merch", {}).items():
         kb.add(types.InlineKeyboardButton(info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"))
-    kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters_next"))
+    kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters"))
     edit(chat_id, "Шаг 4/4. 📦 Остатки — выберите Вид мерча.", kb)
 
 def open_colors(chat_id: int, mk: str):
@@ -86,3 +86,92 @@ def set_all_sizes(chat_id: int, mk: str, ck: str, val: int):
         if inv.get(sz, 0) == 0:
             inv[sz] = val
     open_sizes(chat_id, mk, ck)
+
+
+LAT = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+CYR = list("АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ")
+
+def _letters(chat_id: int):
+    rules = WIZ[chat_id]["data"].setdefault("text_rules", {})
+    letters = []
+    if rules.get("allow_latin", True):
+        letters += LAT
+    if rules.get("allow_cyrillic"):
+        letters += CYR
+    return letters
+
+def open_inventory_letters(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_letters_home"
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for tc in pal:
+        kb.add(types.InlineKeyboardButton(tc, callback_data=f"setup:inv_letters_chars:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("✅ Пропустить", callback_data="setup:finish"))
+    edit(chat_id, "Остатки букв — выберите <b>цвет текста</b>.", kb)
+
+def open_letters_chars(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_letters:{tc}"
+    letters = _letters(chat_id)
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    kb = types.InlineKeyboardMarkup(row_width=6)
+    for ch in letters:
+        qty = inv.get(ch, 0)
+        kb.add(types.InlineKeyboardButton(f"{ch}: {qty}", callback_data=f"setup:inv_lt_qty:{tc}:{ch}"))
+    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_lt_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
+    edit(chat_id, f"Остатки букв: <b>{tc}</b> — выберите букву.", kb)
+
+def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_qty:{tc}:{ch}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    cur = inv.get(ch, 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_lt_set:{tc}:{ch}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_lt_set:{tc}:{ch}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_lt_set:{tc}:{ch}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_lt_set:{tc}:{ch}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_lt_set:{tc}:{ch}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_lt_save:{tc}:{ch}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к буквам", callback_data=f"setup:inv_letters_chars:{tc}"))
+    edit(chat_id, f"Введите количество для <b>{ch}</b> цвета <b>{tc}</b>:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_letter_qty(chat_id: int, tc: str, ch: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    cur = inv.get(ch, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[ch] = cur
+    open_letter_qty_spinner(chat_id, tc, ch)
+
+def set_letter_qty(chat_id: int, tc: str, ch: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    inv[ch] = max(0, val)
+    open_letter_qty_spinner(chat_id, tc, ch)
+
+def save_letter_qty(chat_id: int, tc: str, ch: str):
+    open_letters_chars(chat_id, tc)
+
+def apply_all_letters(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_apply_all:{tc}"
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for val in (0,1,2,5,10,15,20,25,30):
+        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_lt_all_set:{tc}:{val}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_letters_chars:{tc}"))
+    edit(chat_id, f"Применить одно число ко всем буквам <b>{tc}</b>.", kb)
+
+def set_all_letters(chat_id: int, tc: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    for ch in _letters(chat_id):
+        if inv.get(ch, 0) == 0:
+            inv[ch] = val
+    open_letters_chars(chat_id, tc)

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -11,8 +11,9 @@ WIZ: Dict[int, Dict[str, Any]] = {}  # {"anchor_id", "stage", "data", "_sig"}
 
 def ensure(chat_id: int, anchor_id: int | None = None):
     state = WIZ.setdefault(chat_id, {"anchor_id": None, "stage": "home", "data": {}, "_sig": None})
-    if anchor_id and not state["anchor_id"]:
-        state["anchor_id"] = anchor_id
+    if anchor_id:
+        if not state["anchor_id"] or anchor_id > state["anchor_id"]:
+            state["anchor_id"] = anchor_id
 
 def anchor(chat_id: int) -> int:
     return WIZ[chat_id]["anchor_id"]
@@ -66,7 +67,7 @@ def merch_tree(data: dict) -> str:
         colors = list(mi.get("colors", {}).values())
         for ci in colors:
             lines.append(f"  - {ci.get('name_ru', '—')}")
-    return "\\n".join(lines)
+    return "\n".join(lines)
 
 def home_text(d: dict) -> str:
     merch = d.get("merch", {})
@@ -97,11 +98,9 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block: List[str] = []
-    block.append("<b>🎛 МАСТЕР НАСТРОЙКИ</b>\\n")
-
     block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
     block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
-    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\\n")
+    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\n")
 
     block.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
     alph: List[str] = []
@@ -113,15 +112,15 @@ def home_text(d: dict) -> str:
     block.append("├─ Пределы:")
     block.append(f"│ ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
     block.append(f"│ └─ Номер: ≤ {rules.get('max_number', '—')}")
-    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\\n")
+    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\n")
 
     block.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
     block.append("└─ Соответствия:")
-    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\\n")
+    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\n")
 
     block.append(f"🖼 Макеты [{_on_off(nums_set)}]")
     block.append(f"├─ Номера: {'✅' if nums_set else '❌'}")
-    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\\n")
+    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\n")
 
     block.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
     block.append(f"├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
@@ -129,4 +128,5 @@ def home_text(d: dict) -> str:
     block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
     block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
 
-    return "\\n".join(block)
+    body = "\n".join(block)
+    return f"<b>🎛 МАСТЕР НАСТРОЙКИ</b>\n<pre>{body}</pre>"

--- a/handlers/setup/router.py
+++ b/handlers/setup/router.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from bot import bot
-from .core import WIZ, ensure, edit
+from .core import WIZ, ensure, edit, anchor
 
 from . import A0_Overview as O
 from . import A1_Merch    as M
@@ -18,6 +18,9 @@ from . import A9_InventorySizes   as INV
 def setup_router(c: types.CallbackQuery):
     chat_id = c.message.chat.id
     ensure(chat_id, c.message.message_id)
+    if anchor(chat_id) != c.message.message_id:
+        bot.answer_callback_query(c.id)
+        return
     parts = c.data.split(":")
     cmd, *rest = parts[1:]
 
@@ -26,7 +29,7 @@ def setup_router(c: types.CallbackQuery):
     if cmd == "bind_hint":
         kb = types.InlineKeyboardMarkup()
         kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:home"))
-        edit(chat_id, "📌 Привязка общего чата:\\n1) Добавьте бота в нужную группу/канал (в канале — как администратора).\\n2) Выполните там команду /bind_here.\\nБот запомнит чат (и тему, если есть).", kb)
+        edit(chat_id, "<pre>📌 Привязка общего чата:\n1) Добавьте бота в нужную группу/канал (в канале — как администратора).\n2) Выполните там команду /bind_here.\nБот запомнит чат (и тему, если есть).</pre>", kb)
         return
 
     # --- Step 1: Merch ---
@@ -73,16 +76,12 @@ def setup_router(c: types.CallbackQuery):
         edit(chat_id, "Шаг 3/4. Выберите вид мерча для ввода номеров макетов.", kb)
         WIZ[chat_id]["stage"] = "tmpls_pick"; return
     if cmd == "tmpl_nums_for":         TNUM.start_for_merch(chat_id, rest[0]); return
-    if cmd == "tmpl_num_key":          TNUM.keypress(chat_id, rest[0]); return
-    if cmd == "tmpl_num_back":         TNUM.backspace(chat_id); return
-    if cmd == "tmpl_num_clear":        TNUM.clearbuf(chat_id); return
-    if cmd == "tmpl_num_add":          TNUM.add_number(chat_id); return
     if cmd == "tmpl_num_done":         TNUM.done(chat_id); return
     if cmd == "tmpl_color_toggle":     TCOL.toggle_color(chat_id, rest[0], rest[1], rest[2]); return
     if cmd == "tmpl_color_next":       TCOL.next_template(chat_id, rest[0], rest[1]); return
     if cmd == "tmpl_collages_done":    TCOLL.collages_done(chat_id); return
 
-    # --- Step 4: Inventory (sizes) ---
+    # --- Step 4: Inventory ---
     if cmd == "inv":                    INV.open_inventory_sizes(chat_id); return
     if cmd == "inv_sizes_colors":       INV.open_colors(chat_id, rest[0]); return
     if cmd == "inv_sizes_sizes":        INV.open_sizes(chat_id, rest[0], rest[1]); return
@@ -92,6 +91,14 @@ def setup_router(c: types.CallbackQuery):
     if cmd == "inv_sz_save":            INV.save_qty(chat_id, rest[0], rest[1], rest[2]); return
     if cmd == "inv_sz_apply_all":       INV.apply_all_sizes(chat_id, rest[0], rest[1]); return
     if cmd == "inv_sz_all_set":         INV.set_all_sizes(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_letters":            INV.open_inventory_letters(chat_id); return
+    if cmd == "inv_letters_chars":      INV.open_letters_chars(chat_id, rest[0]); return
+    if cmd == "inv_lt_qty":             INV.open_letter_qty_spinner(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_lt_adj":             INV.adjust_letter_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_lt_set":             INV.set_letter_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_lt_save":            INV.save_letter_qty(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_lt_apply_all":       INV.apply_all_letters(chat_id, rest[0]); return
+    if cmd == "inv_lt_all_set":         INV.set_all_letters(chat_id, rest[0], int(rest[1])); return
 
     # --- Finish ---
     if cmd == "finish":                 _finish(chat_id); return
@@ -139,6 +146,8 @@ def _during_setup(m: types.Message):
         from .A1_Merch import handle_custom_sizes; mk = st.split(":")[1]; handle_custom_sizes(chat_id, mk, text)
     elif st == "pal_add" and text:
         from .A4_TextPalette import handle_custom_color; handle_custom_color(chat_id, text)
+    elif st == "tmpl_nums_enter" and text:
+        from .A6_TemplatesNumbers import handle_input; handle_input(chat_id, text)
     # --- коллажи (фото) ---
     elif st.startswith("tmpl_collages:") and m.content_type == "photo":
         mk = st.split(":")[1]

--- a/repositories/files.py
+++ b/repositories/files.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
-import os, json
+"""Utility helpers for persisting small JSON files.
+
+The previous implementation wrote directly to the destination path which
+could lead to partially written files if the process crashed mid-write. In
+addition, JSON parsing errors were silently swallowed which made diagnosing
+corrupted files difficult.  This module now writes files atomically and
+logs any I/O or JSON errors to aid debugging and improve reliability.
+"""
+
+import json
+import logging
+import os
+import tempfile
 from typing import Any, Dict
+
 import config
+
+log = logging.getLogger(__name__)
 
 def _ensure_dir(path: str) -> None:
     if not os.path.exists(path):
@@ -14,6 +28,14 @@ def _path(filename: str) -> str:
     return os.path.join(config.JSON_DIR, filename)
 
 def load_json(filename: str) -> Dict[str, Any]:
+    """Load JSON data from *filename*.
+
+    Any :class:`OSError` or :class:`json.JSONDecodeError` is logged and an
+    empty dictionary is returned instead of propagating the exception. This
+    mirrors the previous behaviour while providing insight into what went
+    wrong.
+    """
+
     path = _path(filename)
     if not os.path.exists(path):
         return {}
@@ -21,11 +43,34 @@ def load_json(filename: str) -> Dict[str, Any]:
         with open(path, "r", encoding="utf-8") as f:
             text = f.read().strip()
             return json.loads(text) if text else {}
-    except Exception:
+    except (OSError, json.JSONDecodeError) as err:
+        log.warning("Failed to load JSON from %s: %s", path, err)
         return {}
 
 def save_json(filename: str, data: Dict[str, Any]) -> None:
+    """Persist *data* to *filename* atomically.
+
+    Writing is performed to a temporary file which is then moved into place.
+    This prevents partially written files if the process crashes during
+    serialisation. Any :class:`OSError` encountered is logged and re-raised
+    so callers can react appropriately.
+    """
+
     path = _path(filename)
-    _ensure_dir(os.path.dirname(path))
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    directory = os.path.dirname(path)
+    _ensure_dir(directory)
+
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=os.path.basename(path))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(data, tmp_file, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        log.warning("Failed to write JSON to %s: %s", path, err)
+        raise
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass

--- a/router.py
+++ b/router.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, order_flow, errors  # noqa: F401
+from handlers import start, bind, order_flow, errors  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 
 def register_routes():
     # Базовые обработчики
-    from handlers import start  # noqa: F401
+    from handlers import start, bind  # noqa: F401
 
     # Мастер настройки: достаточно импортировать модуль,
     # его декораторы сами зарегистрируют хэндлеры.


### PR DESCRIPTION
## Summary
- preserve master setup and merch screens with `<pre>` blocks for stable tree-style layout
- allow returning to merch type list from size entry and add `/bind_here` command to save admin chat
- route all admin notifications through stored chat binding
- fix newline escaping so every setup message renders its tree-style structure
- accept comma-separated template names (Latin or Cyrillic) and track them by merch
- ignore callbacks from stale setup messages, only editing the latest one
- hook up the “Готово → Буквы” inventory button with a full letter-stock editor and enable text-color mapping refresh when palette changes

## Testing
- `python -m pytest`
- `python -m py_compile handlers/setup/A5_MapTextColors.py handlers/setup/A9_InventorySizes.py handlers/setup/router.py`


------
https://chatgpt.com/codex/tasks/task_e_6898470b11ec83248363957963ba1ad3