### PR TITLE
Add role-based access control and order command

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.settings import save_admin_bind
+from services.roles import is_main_admin
+
+@bot.message_handler(commands=["bind_here"])
+def bind_here_cmd(message: types.Message):
+    if not is_main_admin(message.from_user.id):
+        return
+    thread_id = getattr(message, "message_thread_id", None)
+    save_admin_bind(message.chat.id, thread_id)
+    bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/rights.py
+++ b/handlers/rights.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Handlers for administering admin rights."""
+from telebot import types
+from bot import bot
+from services.roles import (
+    add_admin,
+    remove_admin,
+    get_admins,
+    is_main_admin,
+    MAIN_ADMIN_ID,
+)
+from utils.tg import safe_delete
+
+# chat.id -> mode ("add" or "del") waiting for a forwarded message/ID
+RIGHTS_WAIT = {}
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "rights:init")
+def rights_menu(c: types.CallbackQuery):
+    if not is_main_admin(c.from_user.id):
+        bot.answer_callback_query(c.id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(
+        types.InlineKeyboardButton("➕ Выдать права", callback_data="rights:add"),
+        types.InlineKeyboardButton("➖ Удалить права", callback_data="rights:del"),
+        types.InlineKeyboardButton("📋 Список админов", callback_data="rights:list"),
+    )
+    bot.edit_message_text("Выберите действие:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data in {"rights:add", "rights:del"})
+def rights_prompt(c: types.CallbackQuery):
+    if not is_main_admin(c.from_user.id):
+        bot.answer_callback_query(c.id)
+        return
+    mode = "add" if c.data.endswith("add") else "del"
+    RIGHTS_WAIT[c.message.chat.id] = mode
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("Отмена", callback_data="rights:cancel"))
+    action = "выдачи" if mode == "add" else "удаления"
+    bot.edit_message_text(
+        f"Перешлите сообщение пользователя или отправьте его ID для {action} прав администратора.",
+        c.message.chat.id,
+        c.message.message_id,
+        reply_markup=kb,
+    )
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "rights:list")
+def rights_list(c: types.CallbackQuery):
+    if not is_main_admin(c.from_user.id):
+        bot.answer_callback_query(c.id)
+        return
+    admins = get_admins()
+    text = "Список админов:\n" + "\n".join([str(MAIN_ADMIN_ID)] + [str(a) for a in admins])
+    bot.answer_callback_query(c.id)
+    bot.edit_message_text(text, c.message.chat.id, c.message.message_id)
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "rights:cancel")
+def rights_cancel(c: types.CallbackQuery):
+    RIGHTS_WAIT.pop(c.message.chat.id, None)
+    bot.edit_message_text("Отменено.", c.message.chat.id, c.message.message_id)
+
+
+@bot.message_handler(func=lambda m: m.chat.id in RIGHTS_WAIT)
+def rights_handle(m: types.Message):
+    if not is_main_admin(m.from_user.id):
+        return
+    uid = None
+    if m.forward_from:
+        uid = m.forward_from.id
+    else:
+        try:
+            uid = int(m.text.strip())
+        except Exception:
+            pass
+    if not uid:
+        bot.reply_to(m, "Не удалось определить ID.")
+        return
+    mode = RIGHTS_WAIT.pop(m.chat.id)
+    if mode == "add":
+        add_admin(uid)
+        bot.reply_to(m, f"Пользователь {uid} назначен администратором.")
+    else:
+        remove_admin(uid)
+        bot.reply_to(m, f"Пользователь {uid} удалён из администраторов.")
+    safe_delete(bot, m.chat.id, m.message_id)

--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -10,7 +10,8 @@ ONESIZE        = ["OneSize"]
 
 def _header_with_tree(chat_id: int, title: str) -> str:
     d = WIZ[chat_id]["data"]
-    return "<pre>" + title + "\\n\\n<b>Структура</b>\\n" + (merch_tree(d) or "—") + "\\n</pre>"
+    tree = merch_tree(d)
+    return f"<b>{title}</b>\n<pre>Структура\n{tree}\n</pre>"
 
 def render_types(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
@@ -99,7 +100,8 @@ def render_sizes(chat_id: int, mk: str):
     if sizes:
         kb.add(types.InlineKeyboardButton("Сохранить и следующий", callback_data="setup:next_merch_or_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к цветам", callback_data=f"setup:colors:{mk}"))
-    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\\nТекущие: {sizes_text}"), kb)
+    kb.add(types.InlineKeyboardButton("↩️ К видам мерча", callback_data="setup:merch"))
+    edit(chat_id, _header_with_tree(chat_id, f"Шаг 1.2/4. <b>{item['name_ru']}</b> — размеры.\nТекущие: {sizes_text}"), kb)
     WIZ[chat_id]["stage"] = f"sizes:{mk}"
 
 def set_default_sizes(chat_id: int, mk: str):

--- a/handlers/setup/A5_MapTextColors.py
+++ b/handlers/setup/A5_MapTextColors.py
@@ -31,6 +31,10 @@ def render_pair(chat_id: int, mk: str, ck: str) -> None:
     )
     WIZ[chat_id]["stage"] = "map_text_colors"
 
+    # mark this pair as reviewed under current palette size
+    seen = d.setdefault("_maptc_seen", {}).setdefault(mk, {})
+    seen[ck] = len(pal)
+
 
 def render_next_pair(chat_id: int) -> None:
     d = WIZ[chat_id]["data"]
@@ -49,9 +53,13 @@ def render_next_pair(chat_id: int) -> None:
         WIZ[chat_id]["stage"] = "map_text_colors"
         return
 
+    seen = d.setdefault("_maptc_seen", {})
     for mk, mi in merch.items():
         for ck in mi.get("colors", {}):
             cur = d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, [])
+            if seen.get(mk, {}).get(ck) != len(pal):
+                render_pair(chat_id, mk, ck)
+                return
             if not cur and pal:
                 render_pair(chat_id, mk, ck)
                 return

--- a/handlers/setup/A6_TemplatesNumbers.py
+++ b/handlers/setup/A6_TemplatesNumbers.py
@@ -1,54 +1,41 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
 
-def start_for_merch(chat_id: int, mk: str):
-    WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
-    WIZ[chat_id]["data"]["_tmpl_current_mk"] = mk
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
 
-def render_builder(chat_id: int):
+def start_for_merch(chat_id: int, mk: str):
+    data = WIZ[chat_id]["data"].setdefault("templates", {})
+    data.setdefault(mk, {"templates": {}, "collages": []})
+    WIZ[chat_id]["data"]["_tmpl_current_mk"] = mk
+    render_prompt(chat_id)
+
+
+def render_prompt(chat_id: int):
     mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
     d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
     existing = ", ".join(sorted(d.keys())) or "—"
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for row in (("1","2","3"),("4","5","6"),("7","8","9")):
-        kb.add(*(types.InlineKeyboardButton(x, callback_data=f"setup:tmpl_num_key:{x}") for x in row))
-    kb.add(types.InlineKeyboardButton("⌫", callback_data="setup:tmpl_num_back"),
-            types.InlineKeyboardButton("0", callback_data="setup:tmpl_num_key:0"),
-            types.InlineKeyboardButton("✖", callback_data="setup:tmpl_num_clear"))
-    kb.add(types.InlineKeyboardButton("➕ Добавить номер", callback_data="setup:tmpl_num_add"))
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:tmpl_num_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
-    edit(chat_id, f"Шаг 3/4. Ввод номеров макетов ({mk}).\\nТекущий: <b>{buf or '—'}</b>\\nСписок: {existing}", kb)
-    WIZ[chat_id]["stage"] = "tmpl_numbers_builder"
+    edit(chat_id,
+         f"Шаг 3/4. Введите номера макетов ({mk}) через запятую.\nСписок: {existing}",
+         kb)
+    WIZ[chat_id]["stage"] = "tmpl_nums_enter"
 
-def keypress(chat_id: int, k: str):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    if len(buf) < 6:
-        buf += k
-    WIZ[chat_id]["data"]["_num_buf"] = buf
-    render_builder(chat_id)
 
-def backspace(chat_id: int):
-    buf = WIZ[chat_id]["data"].get("_num_buf","")
-    WIZ[chat_id]["data"]["_num_buf"] = buf[:-1]
-    render_builder(chat_id)
-
-def clearbuf(chat_id: int):
-    WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
-
-def add_number(chat_id: int):
+def handle_input(chat_id: int, text: str):
+    import re
     mk = WIZ[chat_id]["data"]["_tmpl_current_mk"]
-    buf = WIZ[chat_id]["data"].get("_num_buf","").strip()
-    if buf:
-        WIZ[chat_id]["data"]["templates"][mk]["templates"].setdefault(buf, {"allowed_colors": []})
-        WIZ[chat_id]["data"]["_num_buf"] = ""
-    render_builder(chat_id)
+    d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
+    parts = [p.strip() for p in text.replace("\n", ",").split(",")]
+    for p in parts:
+        if not p:
+            continue
+        token = p.upper()
+        if len(token) <= 6 and re.fullmatch(r"[0-9A-ZА-Я]+", token):
+            d.setdefault(token, {"allowed_colors": []})
+    render_prompt(chat_id)
+
 
 def done(chat_id: int):
     from .A7_TemplatesColors import render_for_next_template

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -9,7 +9,7 @@ def open_inventory_sizes(chat_id: int):
     kb = types.InlineKeyboardMarkup(row_width=2)
     for mk, info in d.get("merch", {}).items():
         kb.add(types.InlineKeyboardButton(info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"))
-    kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters_next"))
+    kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters"))
     edit(chat_id, "Шаг 4/4. 📦 Остатки — выберите Вид мерча.", kb)
 
 def open_colors(chat_id: int, mk: str):
@@ -86,3 +86,232 @@ def set_all_sizes(chat_id: int, mk: str, ck: str, val: int):
         if inv.get(sz, 0) == 0:
             inv[sz] = val
     open_sizes(chat_id, mk, ck)
+
+
+LAT = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+CYR = list("АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ")
+
+def _letters(chat_id: int):
+    rules = WIZ[chat_id]["data"].setdefault("text_rules", {})
+    letters = []
+    if rules.get("allow_latin", True):
+        letters += LAT
+    if rules.get("allow_cyrillic"):
+        letters += CYR
+    return letters
+
+def open_inventory_letters(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_letters_home"
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for tc in pal:
+        kb.add(types.InlineKeyboardButton(tc, callback_data=f"setup:inv_letters_chars:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("Готово → Цифры", callback_data="setup:inv_numbers"))
+    kb.add(types.InlineKeyboardButton("✅ Пропустить", callback_data="setup:finish"))
+    edit(chat_id, "Остатки букв — выберите <b>цвет текста</b>.", kb)
+
+def open_letters_chars(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_letters:{tc}"
+    letters = _letters(chat_id)
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    kb = types.InlineKeyboardMarkup(row_width=6)
+    for ch in letters:
+        qty = inv.get(ch, 0)
+        kb.add(types.InlineKeyboardButton(f"{ch}: {qty}", callback_data=f"setup:inv_lt_qty:{tc}:{ch}"))
+    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_lt_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
+    edit(chat_id, f"Остатки букв: <b>{tc}</b> — выберите букву.", kb)
+
+def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_qty:{tc}:{ch}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    cur = inv.get(ch, 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_lt_set:{tc}:{ch}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_lt_set:{tc}:{ch}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_lt_set:{tc}:{ch}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_lt_set:{tc}:{ch}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_lt_set:{tc}:{ch}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_lt_save:{tc}:{ch}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к буквам", callback_data=f"setup:inv_letters_chars:{tc}"))
+    edit(chat_id, f"Введите количество для <b>{ch}</b> цвета <b>{tc}</b>:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_letter_qty(chat_id: int, tc: str, ch: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    cur = inv.get(ch, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[ch] = cur
+    open_letter_qty_spinner(chat_id, tc, ch)
+
+def set_letter_qty(chat_id: int, tc: str, ch: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    inv[ch] = max(0, val)
+    open_letter_qty_spinner(chat_id, tc, ch)
+
+def save_letter_qty(chat_id: int, tc: str, ch: str):
+    open_letters_chars(chat_id, tc)
+
+def apply_all_letters(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_lt_apply_all:{tc}"
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for val in (0,1,2,5,10,15,20,25,30):
+        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_lt_all_set:{tc}:{val}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_letters_chars:{tc}"))
+    edit(chat_id, f"Применить одно число ко всем буквам <b>{tc}</b>.", kb)
+
+def set_all_letters(chat_id: int, tc: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+    for ch in _letters(chat_id):
+        if inv.get(ch, 0) == 0:
+            inv[ch] = val
+    open_letters_chars(chat_id, tc)
+
+
+DIGITS = list("0123456789")
+
+def open_inventory_numbers(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_numbers_home"
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for tc in pal:
+        kb.add(types.InlineKeyboardButton(tc, callback_data=f"setup:inv_numbers_digits:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
+    kb.add(types.InlineKeyboardButton("Готово → Макеты", callback_data="setup:inv_templates"))
+    kb.add(types.InlineKeyboardButton("✅ Пропустить", callback_data="setup:finish"))
+    edit(chat_id, "Остатки цифр — выберите <b>цвет текста</b>.", kb)
+
+def open_numbers_digits(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nm_digits:{tc}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("digits", {})
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for dgt in DIGITS:
+        qty = inv.get(dgt, 0)
+        kb.add(types.InlineKeyboardButton(f"{dgt}: {qty}", callback_data=f"setup:inv_nm_qty:{tc}:{dgt}"))
+    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_nm_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_numbers"))
+    edit(chat_id, f"Остатки цифр: <b>{tc}</b> — выберите цифру.", kb)
+
+def open_number_qty_spinner(chat_id: int, tc: str, dgt: str):
+    WIZ[chat_id]["stage"] = f"inv_nm_qty:{tc}:{dgt}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("digits", {})
+    cur = inv.get(dgt, 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_nm_adj:{tc}:{dgt}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_nm_adj:{tc}:{dgt}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_nm_adj:{tc}:{dgt}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_nm_adj:{tc}:{dgt}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_nm_set:{tc}:{dgt}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_nm_set:{tc}:{dgt}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_nm_set:{tc}:{dgt}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_nm_set:{tc}:{dgt}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_nm_set:{tc}:{dgt}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_nm_save:{tc}:{dgt}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к цифрам", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(chat_id, f"Введите количество для цифры <b>{dgt}</b> цвета <b>{tc}</b>:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_number_qty(chat_id: int, tc: str, dgt: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("digits", {})
+    cur = inv.get(dgt, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[dgt] = cur
+    open_number_qty_spinner(chat_id, tc, dgt)
+
+def set_number_qty(chat_id: int, tc: str, dgt: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("digits", {})
+    inv[dgt] = max(0, val)
+    open_number_qty_spinner(chat_id, tc, dgt)
+
+def save_number_qty(chat_id: int, tc: str, dgt: str):
+    open_numbers_digits(chat_id, tc)
+
+def apply_all_numbers(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nm_apply_all:{tc}"
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for val in (0,1,2,5,10,15,20,25,30):
+        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_nm_all_set:{tc}:{val}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(chat_id, f"Применить одно число ко всем цифрам <b>{tc}</b>.", kb)
+
+def set_all_numbers(chat_id: int, tc: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("digits", {})
+    for dgt in DIGITS:
+        if inv.get(dgt, 0) == 0:
+            inv[dgt] = val
+    open_numbers_digits(chat_id, tc)
+
+
+def open_inventory_templates(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_tmpls_home"
+    d = WIZ[chat_id]["data"]
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    for mk, info in d.get("templates", {}).items():
+        kb.add(types.InlineKeyboardButton(WIZ[chat_id]['data']['merch'][mk]['name_ru'], callback_data=f"setup:inv_tmpls_nums:{mk}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_numbers"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:finish"))
+    edit(chat_id, "Остатки макетов — выберите вид мерча.", kb)
+
+def open_template_nums(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_nums:{mk}"
+    nums = WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {})
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for num in sorted(nums.keys(), key=lambda x: (len(x), x)):
+        inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {})
+        qty = inv.get(num, 0)
+        kb.add(types.InlineKeyboardButton(f"{num}: {qty}", callback_data=f"setup:inv_tmpl_qty:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_templates"))
+    edit(chat_id, f"Остатки макетов: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b> — выберите номер.", kb)
+
+def open_template_qty_spinner(chat_id: int, mk: str, num: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_qty:{mk}:{num}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {})
+    cur = inv.get(num, 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_tmpl_save:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к номерам", callback_data=f"setup:inv_tmpls_nums:{mk}"))
+    edit(chat_id, f"Введите количество для макета <b>{mk}/{num}</b>:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_template_qty(chat_id: int, mk: str, num: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {})
+    cur = inv.get(num, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[num] = cur
+    open_template_qty_spinner(chat_id, mk, num)
+
+def set_template_qty(chat_id: int, mk: str, num: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {})
+    inv[num] = max(0, val)
+    open_template_qty_spinner(chat_id, mk, num)
+
+def save_template_qty(chat_id: int, mk: str, num: str):
+    open_template_nums(chat_id, mk)

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -11,8 +11,9 @@ WIZ: Dict[int, Dict[str, Any]] = {}  # {"anchor_id", "stage", "data", "_sig"}
 
 def ensure(chat_id: int, anchor_id: int | None = None):
     state = WIZ.setdefault(chat_id, {"anchor_id": None, "stage": "home", "data": {}, "_sig": None})
-    if anchor_id and not state["anchor_id"]:
-        state["anchor_id"] = anchor_id
+    if anchor_id:
+        if not state["anchor_id"] or anchor_id > state["anchor_id"]:
+            state["anchor_id"] = anchor_id
 
 def anchor(chat_id: int) -> int:
     return WIZ[chat_id]["anchor_id"]
@@ -66,7 +67,7 @@ def merch_tree(data: dict) -> str:
         colors = list(mi.get("colors", {}).values())
         for ci in colors:
             lines.append(f"  - {ci.get('name_ru', '—')}")
-    return "\\n".join(lines)
+    return "\n".join(lines)
 
 def home_text(d: dict) -> str:
     merch = d.get("merch", {})
@@ -97,11 +98,9 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block: List[str] = []
-    block.append("<b>🎛 МАСТЕР НАСТРОЙКИ</b>\\n")
-
     block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
     block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
-    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\\n")
+    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\n")
 
     block.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
     alph: List[str] = []
@@ -113,15 +112,15 @@ def home_text(d: dict) -> str:
     block.append("├─ Пределы:")
     block.append(f"│ ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
     block.append(f"│ └─ Номер: ≤ {rules.get('max_number', '—')}")
-    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\\n")
+    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\n")
 
     block.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
     block.append("└─ Соответствия:")
-    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\\n")
+    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\n")
 
     block.append(f"🖼 Макеты [{_on_off(nums_set)}]")
     block.append(f"├─ Номера: {'✅' if nums_set else '❌'}")
-    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\\n")
+    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\n")
 
     block.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
     block.append(f"├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
@@ -129,4 +128,5 @@ def home_text(d: dict) -> str:
     block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
     block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
 
-    return "\\n".join(block)
+    body = "\n".join(block)
+    return f"<b>🎛 МАСТЕР НАСТРОЙКИ</b>\n<pre>{body}</pre>"

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,15 +2,29 @@
 from telebot import types
 from bot import bot
 from services.settings import get_settings
+from services.roles import is_admin, is_main_admin, is_employee
 
-@bot.message_handler(commands=["start","help"])
+
+@bot.message_handler(commands=["start", "help", "menu"])
 def start_cmd(message: types.Message):
     s = get_settings()
+    uid = message.from_user.id
     kb = types.InlineKeyboardMarkup(row_width=1)
-    if not s.get("configured"):
-        kb.add(types.InlineKeyboardButton("🔧 Запустить мастер настройки", callback_data="setup:init"))
-        kb.add(types.InlineKeyboardButton("ℹ️ Привязка общего чата", callback_data="setup:bind_hint"))
-        bot.send_message(message.chat.id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
-    else:
-        kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="setup:init"))
-        bot.send_message(message.chat.id, "Бот настроен. Выберите действие:", reply_markup=kb)
+
+    if is_admin(uid):
+        kb.add(types.InlineKeyboardButton("1) Настройки проекта", callback_data="setup:init"))
+        if is_main_admin(uid):
+            kb.add(types.InlineKeyboardButton("2) Админка", callback_data="rights:init"))
+        kb.add(types.InlineKeyboardButton("3) Создание заказа", callback_data="order:start"))
+        bot.send_message(message.chat.id, "Выберите команду:", reply_markup=kb)
+        return
+
+    if is_employee(uid):
+        if not s.get("configured"):
+            bot.send_message(message.chat.id, "Бот ещё не настроен. Обратитесь к администратору.")
+            return
+        kb.add(types.InlineKeyboardButton("📝 Создать заказ", callback_data="order:start"))
+        bot.send_message(message.chat.id, "Выберите действие:", reply_markup=kb)
+        return
+
+    bot.send_message(message.chat.id, "Доступ запрещён. Обратитесь к администратору.")

--- a/repositories/files.py
+++ b/repositories/files.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
-import os, json
+"""Utility helpers for persisting small JSON files.
+
+The previous implementation wrote directly to the destination path which
+could lead to partially written files if the process crashed mid-write. In
+addition, JSON parsing errors were silently swallowed which made diagnosing
+corrupted files difficult.  This module now writes files atomically and
+logs any I/O or JSON errors to aid debugging and improve reliability.
+"""
+
+import json
+import logging
+import os
+import tempfile
 from typing import Any, Dict
+
 import config
+
+log = logging.getLogger(__name__)
 
 def _ensure_dir(path: str) -> None:
     if not os.path.exists(path):
@@ -14,6 +28,14 @@ def _path(filename: str) -> str:
     return os.path.join(config.JSON_DIR, filename)
 
 def load_json(filename: str) -> Dict[str, Any]:
+    """Load JSON data from *filename*.
+
+    Any :class:`OSError` or :class:`json.JSONDecodeError` is logged and an
+    empty dictionary is returned instead of propagating the exception. This
+    mirrors the previous behaviour while providing insight into what went
+    wrong.
+    """
+
     path = _path(filename)
     if not os.path.exists(path):
         return {}
@@ -21,11 +43,34 @@ def load_json(filename: str) -> Dict[str, Any]:
         with open(path, "r", encoding="utf-8") as f:
             text = f.read().strip()
             return json.loads(text) if text else {}
-    except Exception:
+    except (OSError, json.JSONDecodeError) as err:
+        log.warning("Failed to load JSON from %s: %s", path, err)
         return {}
 
 def save_json(filename: str, data: Dict[str, Any]) -> None:
+    """Persist *data* to *filename* atomically.
+
+    Writing is performed to a temporary file which is then moved into place.
+    This prevents partially written files if the process crashes during
+    serialisation. Any :class:`OSError` encountered is logged and re-raised
+    so callers can react appropriately.
+    """
+
     path = _path(filename)
-    _ensure_dir(os.path.dirname(path))
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    directory = os.path.dirname(path)
+    _ensure_dir(directory)
+
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=os.path.basename(path))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(data, tmp_file, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        log.warning("Failed to write JSON to %s: %s", path, err)
+        raise
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass

--- a/router.py
+++ b/router.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, order_flow, errors  # noqa: F401
+from handlers import start, bind, order_flow, rights, errors  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 
 def register_routes():
     # Базовые обработчики
-    from handlers import start  # noqa: F401
+    from handlers import start, bind, rights  # noqa: F401
 
     # Мастер настройки: достаточно импортировать модуль,
     # его декораторы сами зарегистрируют хэндлеры.

--- a/services/roles.py
+++ b/services/roles.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Simple role management and access checks."""
+from __future__ import annotations
+
+from typing import List
+from telebot.apihelper import ApiTelegramException
+
+from bot import bot
+import config
+from services.settings import get_admin_bind
+from repositories.files import load_json, save_json
+
+MAIN_ADMIN_ID = 445075408
+ADMINS_FILE = "admins.json"
+
+
+def _load_admins() -> List[int]:
+    data = load_json(ADMINS_FILE)
+    return data.get("admins", [])
+
+
+def _save_admins(admins: List[int]) -> None:
+    save_json(ADMINS_FILE, {"admins": admins})
+
+
+def add_admin(user_id: int) -> None:
+    admins = set(_load_admins())
+    admins.add(int(user_id))
+    _save_admins(sorted(admins))
+
+
+def remove_admin(user_id: int) -> None:
+    admins = set(_load_admins())
+    admins.discard(int(user_id))
+    _save_admins(sorted(admins))
+
+
+def get_admins() -> List[int]:
+    """Return a list of auxiliary admin IDs (excluding the main admin)."""
+    return _load_admins()
+
+
+def is_main_admin(user_id: int) -> bool:
+    return int(user_id) == MAIN_ADMIN_ID
+
+
+def is_admin(user_id: int) -> bool:
+    return is_main_admin(user_id) or int(user_id) in _load_admins()
+
+
+def is_employee(user_id: int) -> bool:
+    """Check if *user_id* is a member of the bound admin chat."""
+    chat_id, _ = get_admin_bind()
+    if not chat_id:
+        chat_id = getattr(config, "ADMIN_CHAT_ID", None)
+    if not chat_id:
+        return False
+    try:
+        member = bot.get_chat_member(chat_id, user_id)
+    except ApiTelegramException:
+        return False
+    return member.status in ("creator", "administrator", "member")


### PR DESCRIPTION
## Summary
- add admin rights management menu so the main admin (445075408) can grant, revoke, or list admins
- expose helper to list stored admins and keep main admin id in code

## Testing
- `python -m pytest`
- `python -m py_compile handlers/rights.py services/roles.py`


------
https://chatgpt.com/codex/tasks/task_e_6898470b11ec83248363957963ba1ad3