### PR TITLE
feat: cache json files to reduce disk io

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.roles import get_role, list_roles, set_role
+
+# simple state storage for role assignment
+_ADMIN_STATE = {}
+
+
+def _ensure_admin(chat_id: int) -> bool:
+    return get_role(chat_id) == "admin"
+
+
+def _home(chat_id: int, message_id: int | None = None):
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(types.InlineKeyboardButton("📋 Список ролей", callback_data="admin:roles"))
+    kb.add(types.InlineKeyboardButton("➕ Назначить роль", callback_data="admin:assign"))
+    if message_id:
+        bot.edit_message_text("Админка", chat_id, message_id, reply_markup=kb)
+    else:
+        bot.send_message(chat_id, "Админка", reply_markup=kb)
+
+
+@bot.message_handler(commands=["admin"])
+def admin_cmd(message: types.Message):
+    if not _ensure_admin(message.chat.id):
+        return
+    _home(message.chat.id)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("admin:"))
+def admin_router(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    if not _ensure_admin(chat_id):
+        bot.answer_callback_query(c.id)
+        return
+    cmd = c.data.split(":", 1)[1]
+    if cmd == "roles":
+        roles = list_roles()
+        text = "\n".join(f"{uid}: {role}" for uid, role in roles.items()) or "Пока нет ролей"
+        kb = types.InlineKeyboardMarkup().add(types.InlineKeyboardButton("⬅️ Назад", callback_data="admin:home"))
+        bot.edit_message_text(text, chat_id, c.message.message_id, reply_markup=kb)
+    elif cmd == "assign":
+        _ADMIN_STATE[chat_id] = "assign"
+        kb = types.InlineKeyboardMarkup().add(types.InlineKeyboardButton("⬅️ Назад", callback_data="admin:home"))
+        bot.edit_message_text("Введите: <chat_id> <role>", chat_id, c.message.message_id, reply_markup=kb)
+    else:
+        _home(chat_id, c.message.message_id)
+    bot.answer_callback_query(c.id)
+
+
+@bot.message_handler(func=lambda m: _ADMIN_STATE.get(m.chat.id) == "assign")
+def admin_assign(m: types.Message):
+    chat_id = m.chat.id
+    if not _ensure_admin(chat_id):
+        return
+    try:
+        uid_str, role = m.text.strip().split(None, 1)
+        set_role(int(uid_str), role.strip())
+        bot.send_message(chat_id, "Роль назначена")
+    except Exception:
+        bot.send_message(chat_id, "Неверный формат")
+    finally:
+        _ADMIN_STATE.pop(chat_id, None)
+        _home(chat_id)

--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -2,9 +2,11 @@
 from telebot import types
 from bot import bot
 from services.settings import save_admin_bind
+from utils.tg import set_chat_commands
 
 @bot.message_handler(commands=["bind_here"])
 def bind_here_cmd(message: types.Message):
     thread_id = getattr(message, "message_thread_id", None)
     save_admin_bind(message.chat.id, thread_id)
+    set_chat_commands(bot, message.chat.id)
     bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -18,6 +18,7 @@ def open_colors(chat_id: int, mk: str):
     kb = types.InlineKeyboardMarkup(row_width=3)
     for ck, ci in colors.items():
         kb.add(types.InlineKeyboardButton(ci["name_ru"], callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv_letters"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_sizes_home"))
     edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b> — выберите цвет.", kb)
 

--- a/handlers/setup/router.py
+++ b/handlers/setup/router.py
@@ -14,9 +14,23 @@ from . import A7_TemplatesColors  as TCOL
 from . import A8_TemplatesCollages as TCOLL
 from . import A9_InventorySizes   as INV
 
+
+@bot.message_handler(commands=["setup"])
+def setup_cmd(message: types.Message):
+    from services.roles import get_role
+    if get_role(message.chat.id) not in ("coord", "admin"):
+        return
+    chat_id = message.chat.id
+    ensure(chat_id, message.message_id)
+    O.render_home(chat_id)
+
 @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("setup:"))
 def setup_router(c: types.CallbackQuery):
+    from services.roles import get_role
     chat_id = c.message.chat.id
+    if get_role(chat_id) not in ("coord", "admin"):
+        bot.answer_callback_query(c.id)
+        return
     ensure(chat_id, c.message.message_id)
     if anchor(chat_id) != c.message.message_id:
         bot.answer_callback_query(c.id)
@@ -83,6 +97,7 @@ def setup_router(c: types.CallbackQuery):
 
     # --- Step 4: Inventory ---
     if cmd == "inv":                    INV.open_inventory_sizes(chat_id); return
+    if cmd == "inv_sizes_home":         INV.open_inventory_sizes(chat_id); return
     if cmd == "inv_sizes_colors":       INV.open_colors(chat_id, rest[0]); return
     if cmd == "inv_sizes_sizes":        INV.open_sizes(chat_id, rest[0], rest[1]); return
     if cmd == "inv_sz_qty":             INV.open_qty_spinner(chat_id, rest[0], rest[1], rest[2]); return

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,15 +2,32 @@
 from telebot import types
 from bot import bot
 from services.settings import get_settings
+from utils.tg import set_chat_commands
 
-@bot.message_handler(commands=["start","help"])
+@bot.message_handler(commands=["start"])
 def start_cmd(message: types.Message):
+    chat_id = message.chat.id
+    set_chat_commands(bot, chat_id)
     s = get_settings()
-    kb = types.InlineKeyboardMarkup(row_width=1)
+    from services.roles import get_role
+
     if not s.get("configured"):
+        kb = types.InlineKeyboardMarkup(row_width=1)
         kb.add(types.InlineKeyboardButton("🔧 Запустить мастер настройки", callback_data="setup:init"))
         kb.add(types.InlineKeyboardButton("ℹ️ Привязка общего чата", callback_data="setup:bind_hint"))
-        bot.send_message(message.chat.id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
-    else:
+        bot.send_message(chat_id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
+        return
+
+    role = get_role(chat_id)
+    if role == "user":
+        return
+
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    if role in ("promo", "coord", "admin"):
+        kb.add(types.InlineKeyboardButton("🛒 Заказ", callback_data="order:start"))
+    if role in ("coord", "admin"):
         kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="setup:init"))
-        bot.send_message(message.chat.id, "Бот настроен. Выберите действие:", reply_markup=kb)
+    if role == "admin":
+        kb.add(types.InlineKeyboardButton("⚙️ Админка", callback_data="admin:home"))
+
+    bot.send_message(chat_id, "Выберите действие:", reply_markup=kb)

--- a/repositories/files.py
+++ b/repositories/files.py
@@ -11,9 +11,16 @@ import json
 import logging
 import os
 import tempfile
+import threading
 from typing import Any, Dict
 
 import config
+
+# In-memory cache for JSON files to minimise disk access.  A single
+# reentrant lock guards both cache lookups and file writes, ensuring that
+# concurrent threads do not read stale data or step on each other's writes.
+_CACHE: Dict[str, Dict[str, Any]] = {}
+_LOCK = threading.RLock()
 
 log = logging.getLogger(__name__)
 
@@ -37,15 +44,24 @@ def load_json(filename: str) -> Dict[str, Any]:
     """
 
     path = _path(filename)
-    if not os.path.exists(path):
-        return {}
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            text = f.read().strip()
-            return json.loads(text) if text else {}
-    except (OSError, json.JSONDecodeError) as err:
-        log.warning("Failed to load JSON from %s: %s", path, err)
-        return {}
+    with _LOCK:
+        if path in _CACHE:
+            # Return a copy so callers cannot accidentally mutate the cache
+            return dict(_CACHE[path])
+
+        if not os.path.exists(path):
+            _CACHE[path] = {}
+            return {}
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read().strip()
+                data = json.loads(text) if text else {}
+        except (OSError, json.JSONDecodeError) as err:
+            log.warning("Failed to load JSON from %s: %s", path, err)
+            data = {}
+
+        _CACHE[path] = data
+        return dict(data)
 
 def save_json(filename: str, data: Dict[str, Any]) -> None:
     """Persist *data* to *filename* atomically.
@@ -65,6 +81,9 @@ def save_json(filename: str, data: Dict[str, Any]) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
             json.dump(data, tmp_file, ensure_ascii=False, indent=2)
         os.replace(tmp_path, path)
+        with _LOCK:
+            # Store a copy to avoid external mutation of the cached object
+            _CACHE[path] = dict(data)
     except OSError as err:
         log.warning("Failed to write JSON to %s: %s", path, err)
         raise

--- a/router.py
+++ b/router.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, bind, order_flow, errors  # noqa: F401
+from handlers import start, bind, order_flow, admin, errors  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 
 def register_routes():
     # Базовые обработчики
-    from handlers import start, bind  # noqa: F401
+    from handlers import start, bind, admin  # noqa: F401
 
     # Мастер настройки: достаточно импортировать модуль,
     # его декораторы сами зарегистрируют хэндлеры.

--- a/services/roles.py
+++ b/services/roles.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Simple per-chat role management."""
+from __future__ import annotations
+from typing import Dict
+from repositories.files import load_json, save_json
+
+ROLES_FILE = "roles.json"
+
+DEFAULT_ROLE = "user"
+MAIN_ADMIN_ID = 445075408
+_DEFAULT_ROLES = {str(MAIN_ADMIN_ID): "admin"}
+
+
+def _load_roles() -> Dict[str, str]:
+    roles = load_json(ROLES_FILE) or {}
+    changed = False
+    for uid, role in _DEFAULT_ROLES.items():
+        if roles.get(uid) != role:
+            roles[uid] = role
+            changed = True
+    if changed:
+        save_json(ROLES_FILE, roles)
+    return roles
+
+
+def get_role(chat_id: int) -> str:
+    """Return role for chat_id."""
+    roles = _load_roles()
+    return roles.get(str(chat_id), DEFAULT_ROLE)
+
+
+def set_role(chat_id: int, role: str) -> None:
+    roles = _load_roles()
+    roles[str(chat_id)] = role
+    save_json(ROLES_FILE, roles)
+
+
+def list_roles() -> Dict[str, str]:
+    return _load_roles()

--- a/utils/tg.py
+++ b/utils/tg.py
@@ -15,3 +15,19 @@ def safe_edit_message(bot: TeleBot, chat_id: int, message_id: int, text: str,
         bot.edit_message_text(text, chat_id, message_id, reply_markup=markup, parse_mode="HTML")
     except Exception:
         pass
+
+
+def set_chat_commands(bot: TeleBot, chat_id: int) -> None:
+    """Configure the command menu for a specific chat based on its rights."""
+    from services.roles import get_role
+
+    role = get_role(chat_id)
+    cmds = [types.BotCommand("start", "Старт")]
+    if role in ("promo", "coord", "admin"):
+        cmds.append(types.BotCommand("order", "Заказ"))
+    if role in ("coord", "admin"):
+        cmds.append(types.BotCommand("setup", "Настройка"))
+    if role == "admin":
+        cmds.append(types.BotCommand("admin", "Админка"))
+
+    bot.set_my_commands(cmds, scope=types.BotCommandScopeChat(chat_id))


### PR DESCRIPTION
## Summary
- cache JSON data with a thread-safe in-memory store to minimise disk access
- add per-chat roles with an admin panel and role-aware command menus
- tailor start flow and order/setup access based on roles
- set 445075408 as the default main admin

## Testing
- `python -m pytest`
- `python -m py_compile services/roles.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d7b455b08324bcf8c18069209ffe