### PR TITLE
feat: cache json files to reduce disk io

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -2,9 +2,11 @@
 from telebot import types
 from bot import bot
 from services.settings import save_admin_bind
+from utils.tg import set_chat_commands
 
 @bot.message_handler(commands=["bind_here"])
 def bind_here_cmd(message: types.Message):
     thread_id = getattr(message, "message_thread_id", None)
     save_admin_bind(message.chat.id, thread_id)
+    set_chat_commands(bot, message.chat.id)
     bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/debug.py
+++ b/handlers/debug.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+
+try:
+    from handlers.order_flow import ORD
+except Exception:
+    ORD = {}
+try:
+    from handlers.setup.core import WIZ
+except Exception:
+    WIZ = {}
+
+
+@bot.message_handler(func=lambda m: True, content_types=['text','photo','document','sticker','video','voice','location','contact'])
+def _log_unhandled_message(m: types.Message):
+    state = ORD.get(m.chat.id, {}).get('step') or WIZ.get(m.chat.id, {}).get('stage')
+    payload = m.text if m.content_type == 'text' else m.content_type
+    print(f"[unhandled message] chat={m.chat.id} state={state} payload={payload}")
+
+
+@bot.callback_query_handler(func=lambda c: True)
+def _log_unhandled_callback(c: types.CallbackQuery):
+    state = ORD.get(c.message.chat.id, {}).get('step') or WIZ.get(c.message.chat.id, {}).get('stage')
+    print(f"[unhandled callback] chat={c.message.chat.id} state={state} data={c.data}")

--- a/handlers/order_flow.py
+++ b/handlers/order_flow.py
@@ -10,7 +10,7 @@ from services.inventory import (
     dec_size, dec_letter, dec_number, dec_template
 )
 from services.validators import validate_text, validate_number
-from utils.tg import safe_delete, safe_edit_message
+from utils.tg import safe_delete, safe_edit_message, color_name_ru
 
 # Временные заказы (по chat_id)
 ORD: dict[int, dict] = {}
@@ -39,138 +39,283 @@ def _send_to_admin_or_warn(user_chat_id: int, text: str) -> None:
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:start")
 def order_start(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    mid = c.message.message_id
     s = get_settings()
     if not s.get("configured"):
         bot.answer_callback_query(c.id)
-        bot.send_message(c.message.chat.id, "Бот не настроен. Нажмите /start и пройдите мастер.")
+        bot.send_message(chat_id, "Бот не настроен. Нажмите /start и пройдите мастер.")
         return
-    merch = s.get("merch", {})
+    inv = get_merch_inv()
+    avail = []
+    for mk, info in s.get("merch", {}).items():
+        colors = s.get("merch", {}).get(mk, {}).get("colors", {})
+        for ck in colors:
+            sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+            if any(q > 0 for q in sizes.values()):
+                avail.append((mk, info))
+                break
+    ORD[chat_id] = {"mid": mid}
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступного мерча. Обновите остатки.")
+        return
+    if len(avail) == 1:
+        mk, info = avail[0]
+        ORD[chat_id]["merch"] = mk
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {info.get('name_ru', mk)} (других вариантов нет)")
+        _prompt_colors(chat_id, mk)
+        return
     kb = types.InlineKeyboardMarkup(row_width=2)
-    for mk, info in merch.items():
+    for mk, info in avail:
         kb.add(types.InlineKeyboardButton(info.get("name_ru", mk), callback_data=f"order:m:{mk}"))
-    bot.edit_message_text("Выберите вид мерча:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    safe_edit_message(bot, chat_id, mid, "Выберите вид мерча:", kb)
+
+
+def _prompt_colors(chat_id: int, mk: str):
+    s = get_settings()
+    inv = get_merch_inv()
+    colors = s.get("merch", {}).get(mk, {}).get("colors", {})
+    avail = []
+    for ck, info in colors.items():
+        sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+        if any(q > 0 for q in sizes.values()):
+            avail.append((ck, info.get("name_ru", ck)))
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных цветов. ⬅️ Назад")
+        return
+    if len(avail) == 1:
+        ck, name = avail[0]
+        ORD[chat_id]["color"] = ck
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {name} (других вариантов нет)")
+        _prompt_sizes(chat_id, mk, ck)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for ck, name in avail:
+        kb.add(types.InlineKeyboardButton(name, callback_data=f"order:c:{mk}:{ck}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет:", kb)
+
+
+def _prompt_sizes(chat_id: int, mk: str, ck: str):
+    inv = get_merch_inv()
+    sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+    avail = [sz for sz, q in sizes.items() if q > 0]
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных размеров. ⬅️ Назад")
+        return
+    if len(avail) == 1:
+        sz = avail[0]
+        ORD[chat_id]["size"] = sz
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {sz} (других вариантов нет)")
+        _after_size(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for sz in avail:
+        kb.add(types.InlineKeyboardButton(sz, callback_data=f"order:s:{mk}:{ck}:{sz}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите размер:", kb)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:m:"))
 def order_choose_merch(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
     mk = c.data.split(":")[2]
-    s = get_settings()
-    inv = get_merch_inv()
-    # показать только цвета, у которых есть доступные размеры (>0)
-    kb = types.InlineKeyboardMarkup(row_width=2)
-    added = False
-    for ck, info in s.get("merch", {}).get(mk, {}).get("colors", {}).items():
-        sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
-        if any(q > 0 for q in sizes.values()):
-            kb.add(types.InlineKeyboardButton(info.get("name_ru", ck), callback_data=f"order:c:{mk}:{ck}"))
-            added = True
-    if not added:
-        bot.answer_callback_query(c.id)
-        bot.send_message(c.message.chat.id, "К сожалению, нет доступных цветов/размеров. Обновите остатки.")
-        return
-    ORD[c.message.chat.id] = {"merch": mk}
-    bot.edit_message_text("Выберите цвет:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    ORD.setdefault(chat_id, {})["merch"] = mk
+    _prompt_colors(chat_id, mk)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:c:"))
 def order_choose_color(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
     _, _, mk, ck = c.data.split(":")
-    inv = get_merch_inv()
-    sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for sz, q in sizes.items():
-        if q > 0:
-            kb.add(types.InlineKeyboardButton(f"{sz}", callback_data=f"order:s:{mk}:{ck}:{sz}"))
-    ORD[c.message.chat.id].update({"color": ck})
-    bot.edit_message_text("Выберите размер:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    ORD.setdefault(chat_id, {})["color"] = ck
+    _prompt_sizes(chat_id, mk, ck)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:s:"))
 def order_choose_size(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    ORD[c.message.chat.id].update({"size": sz})
-    # спросим: нужен текст и/или номер?
-    kb = types.InlineKeyboardMarkup()
-    kb.add(types.InlineKeyboardButton("Текст", callback_data=f"order:text:{mk}:{ck}:{sz}"),
-           types.InlineKeyboardButton("Номер", callback_data=f"order:number:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("Без текста/номера", callback_data=f"order:skiptn:{mk}:{ck}:{sz}"))
-    bot.edit_message_text("Добавить надпись и/или номер?", c.message.chat.id, c.message.message_id, reply_markup=kb)
-
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:text:"))
-def order_text_choose_color(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    s = get_settings()
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    if not tcolors:
-        bot.answer_callback_query(c.id, "Нет допустимых цветов текста для этого цвета мерча.", show_alert=True)
-        return
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:textc:{mk}:{ck}:{sz}:{tc}"))
-    bot.edit_message_text("Выберите цвет текста:", c.message.chat.id, c.message.message_id, reply_markup=kb)
-
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:textc:"))
-def order_text_input(c: types.CallbackQuery):
-    _, _, mk, ck, sz, tc = c.data.split(":")
     chat_id = c.message.chat.id
-    ORD[chat_id]["text_color"] = tc
-    bot.edit_message_text("Введите текст (только буквы выбранных алфавитов и пробелы):", chat_id, c.message.message_id)
+    _, _, mk, ck, sz = c.data.split(":")
+    ORD.setdefault(chat_id, {})["size"] = sz
+    _after_size(chat_id)
+    
+def _after_size(chat_id: int):
+    s = get_settings()
+    feats = s.get("features", {})
+    if feats.get("letters"):
+        _prompt_text(chat_id)
+    elif feats.get("numbers"):
+        _prompt_number(chat_id)
+    else:
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Перейдём к выбору макетов.")
+        _prompt_templates(chat_id)
+
+
+def _prompt_text(chat_id: int):
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Введите текст (только буквы выбранных алфавитов и пробелы):")
     ORD[chat_id]["step"] = "text_wait"
+
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "text_wait")
 def order_text_set(m: types.Message):
-    ok, msg = validate_text(m.text.strip())
-    if not ok:
-        bot.reply_to(m, "⚠️ " + msg); return
-    ORD[m.chat.id]["text"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    bot.reply_to(m, "Текст принят. Использовать номер? /number или /skip")
-
-@bot.message_handler(commands=["number"])
-def cmd_number(m: types.Message):
     chat_id = m.chat.id
-    if chat_id not in ORD: return
-    s = get_settings()
-    mk = ORD[chat_id]["merch"]; ck = ORD[chat_id]["color"]
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    if not tcolors:
-        bot.reply_to(m, "Для выбранного цвета мерча нет допустимых цветов цифр."); return
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:numc:{mk}:{ck}:{ORD[chat_id]['size']}:{tc}"))
-    bot.send_message(chat_id, "Выберите цвет цифр:", reply_markup=kb)
+    mid = ORD.get(chat_id, {}).get("mid")
+    text = m.text.strip()
+    ok, msg = validate_text(text)
+    if not ok:
+        safe_edit_message(bot, chat_id, mid, f"⚠️ {msg}\n\nВведите текст (только буквы выбранных алфавитов и пробелы):")
+        safe_delete(bot, chat_id, m.message_id)
+        return
+    ORD[chat_id]["text"] = text
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_text_color(chat_id)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:number:"))
-def order_number_choose_color(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    s = get_settings()
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:numc:{mk}:{ck}:{sz}:{tc}"))
-    bot.edit_message_text("Выберите цвет цифр:", c.message.chat.id, c.message.message_id, reply_markup=kb)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:numc:"))
-def order_number_input(c: types.CallbackQuery):
-    _, _, mk, ck, sz, tc = c.data.split(":")
+def _prompt_text_color(chat_id: int):
+    s = get_settings()
+    mk = ORD[chat_id]["merch"]
+    ck = ORD[chat_id]["color"]
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_letters_inv()
+    avail = []
+    for tc in tcolors:
+        if any(q > 0 for q in inv.get(tc, {}).get("letters", {}).values()):
+            avail.append(tc)
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных цветов текста.")
+        _prompt_number(chat_id)
+        return
+    if len(avail) == 1:
+        tc = avail[0]
+        ORD[chat_id]["text_color"] = tc
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {color_name_ru(tc)} (других вариантов нет)")
+        _prompt_number(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for tc in avail:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"order:textc:{tc}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет текста:", kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("order:textc:"))
+def order_text_color_cb(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    ORD[chat_id]["number_color"] = tc
-    bot.edit_message_text("Введите номер (0..N):", chat_id, c.message.message_id)
+    tc = c.data.split(":")[2]
+    ORD.setdefault(chat_id, {})["text_color"] = tc
+    letters_inv = get_letters_inv()
+    counts = {}
+    for ch in ORD[chat_id]["text"].replace(" ", "").upper():
+        counts[ch] = counts.get(ch, 0) + 1
+    miss = {ch: cnt for ch, cnt in counts.items()
+            if letters_inv.get(tc, {}).get("letters", {}).get(ch, 0) < cnt}
+    if miss:
+        msg_lines = ["⚠️ Недостаточно символов:"]
+        msg_lines.append("• Буквы: " + ", ".join(f"{k} ×{v}" for k, v in miss.items()))
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "\n".join(msg_lines))
+        _prompt_text(chat_id)
+        return
+    _prompt_number(chat_id)
+
+
+def _prompt_number(chat_id: int):
+    s = get_settings()
+    if not s.get("features", {}).get("numbers"):
+        _prompt_templates(chat_id)
+        return
+    mid = ORD[chat_id]["mid"]
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("Без номера", callback_data="order:number_skip"))
+    safe_edit_message(bot, chat_id, mid, "Введите номер (0..N):", kb)
     ORD[chat_id]["step"] = "number_wait"
+
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "number_wait")
 def order_number_set(m: types.Message):
-    ok, msg = validate_number(m.text.strip())
+    chat_id = m.chat.id
+    mid = ORD.get(chat_id, {}).get("mid")
+    num = m.text.strip()
+    ok, msg = validate_number(num)
     if not ok:
-        bot.reply_to(m, "⚠️ " + msg); return
-    ORD[m.chat.id]["number"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _prompt_templates(m.chat.id)
+        safe_edit_message(bot, chat_id, mid, f"⚠️ {msg}\n\nВведите номер (0..N):")
+        safe_delete(bot, chat_id, m.message_id)
+        return
+    ORD[chat_id]["number"] = num
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_number_color(chat_id)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:skiptn:"))
-def order_skip_text_number(c: types.CallbackQuery):
+
+@bot.callback_query_handler(func=lambda c: c.data == "order:number_skip")
+def order_number_skip(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    ORD[chat_id]["text"] = "Без текста"
-    ORD[chat_id]["number"] = "Без номера"
-    bot.edit_message_text("Перейдём к выбору макетов.", chat_id, c.message.message_id)
+    ORD.setdefault(chat_id, {})["number"] = "Без номера"
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, "Перейдём к выбору макетов.")
     _prompt_templates(chat_id)
+
+
+def _prompt_number_color(chat_id: int):
+    s = get_settings()
+    mk = ORD[chat_id]["merch"]; ck = ORD[chat_id]["color"]
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_numbers_inv()
+    avail = []
+    for tc in tcolors:
+        if any(q > 0 for q in inv.get(tc, {}).get("numbers", {}).values()):
+            avail.append(tc)
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        _prompt_templates(chat_id)
+        return
+    if len(avail) == 1:
+        tc = avail[0]
+        ORD[chat_id]["number_color"] = tc
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {color_name_ru(tc)} (других вариантов нет)")
+        _prompt_templates(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for tc in avail:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"order:numc:{tc}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет цифр:", kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("order:numc:"))
+def order_number_color_cb(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    tc = c.data.split(":")[2]
+    ORD.setdefault(chat_id, {})["number_color"] = tc
+    numbers_inv = get_numbers_inv()
+    counts = {}
+    for dg in ORD[chat_id]["number"]:
+        counts[dg] = counts.get(dg, 0) + 1
+    miss = {dg: cnt for dg, cnt in counts.items()
+            if numbers_inv.get(tc, {}).get("numbers", {}).get(dg, 0) < cnt}
+    if miss:
+        msg_lines = ["⚠️ Недостаточно символов:"]
+        msg_lines.append("• Цифры: " + ", ".join(f"{k} ×{v}" for k, v in miss.items()))
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "\n".join(msg_lines))
+        _prompt_number(chat_id)
+        return
+    _prompt_templates(chat_id)
+
+def _render_tpl_step(chat_id: int):
+    avail = ORD[chat_id]["avail_tpls"]
+    sel = ORD[chat_id].get("selected_tpls", [])
+    limit = ORD[chat_id].get("tpl_limit", len(avail))
+    kb = types.InlineKeyboardMarkup(row_width=4)
+    for n in sorted(avail):
+        label = f"🟩 {n}" if n in sel else n
+        kb.add(types.InlineKeyboardButton(label, callback_data=f"order:tpl:{n}"))
+    kb.add(types.InlineKeyboardButton("Дальше", callback_data="order:tpl_done"))
+    kb.add(types.InlineKeyboardButton("Очистить выбор макетов", callback_data="order:tpl_clear"))
+    text = f"Макеты ({len(sel)}/{limit}): {', '.join(sel) if sel else '—'}"
+    safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], text, kb)
+
 
 def _prompt_templates(chat_id: int):
     s = get_settings(); invt = get_templates_inv()
@@ -187,47 +332,60 @@ def _prompt_templates(chat_id: int):
         for fid in tmpl_def["collages"][:5]:
             try: bot.send_photo(chat_id, fid)
             except Exception: pass
+    mid = ORD[chat_id]["mid"]
     if not avail:
+        safe_edit_message(bot, chat_id, mid, "Доступных макетов нет.")
         _prompt_comment_phone(chat_id)
         return
-    kb = types.InlineKeyboardMarkup(row_width=4)
-    for n in sorted(avail):
-        kb.add(types.InlineKeyboardButton(n, callback_data=f"order:tpl:{n}"))
-    kb.add(types.InlineKeyboardButton("Готово", callback_data="order:tpl_done"),
-           types.InlineKeyboardButton("Без макета", callback_data="order:tpl_none"))
-    bot.send_message(chat_id, "Выберите номера макетов (можно несколько):", reply_markup=kb)
+    if len(avail) == 1:
+        ORD[chat_id]["templates"] = avail[0]
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {avail[0]} (других вариантов нет)")
+        _prompt_comment_phone(chat_id)
+        return
+    ORD[chat_id]["avail_tpls"] = avail
     ORD[chat_id]["selected_tpls"] = []
+    ORD[chat_id]["tpl_limit"] = tmpl_def.get("limit", len(avail))
+    _render_tpl_step(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:tpl"))
 def order_tpl_cb(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    if c.data == "order:tpl_none":
-        ORD[chat_id]["templates"] = "Без макета"
-        bot.answer_callback_query(c.id, "Без макета")
-        _prompt_comment_phone(chat_id)
-        return
     if c.data == "order:tpl_done":
         ORD[chat_id]["templates"] = ", ".join(sorted(set(ORD[chat_id].get("selected_tpls", [])))) or "Без макета"
         _prompt_comment_phone(chat_id)
+        return
+    if c.data == "order:tpl_clear":
+        ORD[chat_id]["selected_tpls"] = []
+        bot.answer_callback_query(c.id, "Очищено")
+        _render_tpl_step(chat_id)
         return
     n = c.data.split(":")[2]
     lst = ORD[chat_id].setdefault("selected_tpls", [])
     if n in lst:
         lst.remove(n); bot.answer_callback_query(c.id, f"Убрано: {n}")
     else:
-        lst.append(n); bot.answer_callback_query(c.id, f"Добавлено: {n}")
+        lim = ORD[chat_id].get("tpl_limit", len(ORD[chat_id].get("avail_tpls", [])))
+        if len(lst) < lim:
+            lst.append(n); bot.answer_callback_query(c.id, f"Добавлено: {n}")
+        else:
+            bot.answer_callback_query(c.id, "Достигнут лимит")
+    _render_tpl_step(chat_id)
 
 def _prompt_comment_phone(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="order:skip_comment"))
-    bot.send_message(chat_id, "Добавить комментарий к заказу?", reply_markup=kb)
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Добавить комментарий к заказу?", kb)
     ORD[chat_id]["step"] = "comment_wait"
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "comment_wait")
 def order_comment_set(m: types.Message):
-    ORD[m.chat.id]["comment"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _prompt_phone(m.chat.id)
+    chat_id = m.chat.id
+    ORD[chat_id]["comment"] = m.text.strip()
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_phone(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:skip_comment")
 def order_skip_comment(c: types.CallbackQuery):
@@ -239,14 +397,17 @@ def order_skip_comment(c: types.CallbackQuery):
 def _prompt_phone(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="order:skip_phone"))
-    bot.send_message(chat_id, "Введите номер телефона (или пропустите):", reply_markup=kb)
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Введите номер телефона (или пропустите):", kb)
     ORD[chat_id]["step"] = "phone_wait"
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "phone_wait")
 def order_phone_set(m: types.Message):
-    ORD[m.chat.id]["phone"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _show_summary(m.chat.id)
+    chat_id = m.chat.id
+    ORD[chat_id]["phone"] = m.text.strip()
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _show_summary(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:skip_phone")
 def order_skip_phone(c: types.CallbackQuery):
@@ -265,23 +426,45 @@ def _show_summary(chat_id: int):
         f"Мерч: {html.escape(merch_name)}",
         f"Цвет: {html.escape(color_name)}",
         f"Размер: {html.escape(d['size'])}",
-        f"Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(d.get('text_color','-'))})",
-        f"Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(d.get('number_color','-'))})",
+        f"Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(color_name_ru(d.get('text_color','-')))})",
+        f"Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(color_name_ru(d.get('number_color','-')))})",
         f"Макеты: {html.escape(d.get('templates','Без макета'))}",
     ]
     if d.get("phone"):
         lines.append(f"Телефон: {html.escape(d['phone'])}")
     if d.get("comment"):
         lines.append(f"Комментарий: {html.escape(d['comment'])}")
+    letters_inv = get_letters_inv(); numbers_inv = get_numbers_inv()
+    miss_lt = []
+    if d.get("text") and d["text"] != "Без текста":
+        for ch in d["text"].replace(" ", "").upper():
+            if letters_inv.get(d.get("text_color"), {}).get("letters", {}).get(ch, 0) <= 0:
+                miss_lt.append(ch)
+    miss_nb = []
+    if d.get("number") and d["number"] != "Без номера":
+        for digit in d["number"]:
+            if numbers_inv.get(d.get("number_color"), {}).get("numbers", {}).get(digit, 0) <= 0:
+                miss_nb.append(digit)
+    if miss_lt:
+        bot.send_message(chat_id, f"⚠️ Не хватает букв: {', '.join(sorted(set(miss_lt)))}")
+        _prompt_text(chat_id)
+        return
+    if miss_nb:
+        bot.send_message(chat_id, f"⚠️ Не хватает цифр: {', '.join(sorted(set(miss_nb)))}")
+        _prompt_number(chat_id)
+        return
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Отправить в печать ✅", callback_data="order:confirm_yes"),
            types.InlineKeyboardButton("Отмена", callback_data="order:confirm_no"))
-    bot.send_message(chat_id, "\n".join(lines), reply_markup=kb)
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "\n".join(lines), kb)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:confirm_no")
 def order_confirm_no(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    bot.edit_message_text("🛑 Заказ отменён. /start — начать заново.", chat_id, c.message.message_id)
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, "🛑 Заказ отменён. /start — начать заново.")
+    ORD.pop(chat_id, None)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:confirm_yes")
 def order_confirm_yes(c: types.CallbackQuery):
@@ -297,8 +480,8 @@ def order_confirm_yes(c: types.CallbackQuery):
         f"🛍 Мерч: {html.escape(merch_name)}\n"
         f"🎨 Цвет: {html.escape(color_name)}\n"
         f"📐 Размер: {html.escape(d['size'])}\n"
-        f"📝 Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(d.get('text_color','-'))})\n"
-        f"🔢 Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(d.get('number_color','-'))})\n"
+        f"📝 Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(color_name_ru(d.get('text_color','-')))})\n"
+        f"🔢 Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(color_name_ru(d.get('number_color','-')))})\n"
         f"🖼 Макеты: {html.escape(d.get('templates','Без макета'))}\n"
     )
     if d.get("comment"):
@@ -316,9 +499,11 @@ def order_confirm_yes(c: types.CallbackQuery):
         for num in d["templates"].split(","):
             dec_template(d["merch"], num.strip())
 
-    bot.edit_message_text(final_text, chat_id, c.message.message_id, parse_mode="HTML")
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, final_text)
     _send_to_admin_or_warn(chat_id, final_text)
 
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Сделать новый заказ", callback_data="order:start"))
     bot.send_message(chat_id, "✅ Заказ оформлен!", reply_markup=kb)
+    ORD.pop(chat_id, None)

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+
+from handlers.setup.A0_Overview import render_home
+from handlers.setup.core import ensure
+
+try:
+    from handlers.order_flow import ORD
+except Exception:
+    ORD = {}
+
+
+def _open_settings(chat_id: int, mid: int):
+    ORD.pop(chat_id, None)
+    ensure(chat_id, mid)
+    render_home(chat_id)
+
+
+@bot.message_handler(func=lambda m: (m.text or "").strip().lower() == "настройки")
+def settings_msg(m: types.Message):
+    _open_settings(m.chat.id, m.message_id)
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "settings_open")
+def settings_cb(c: types.CallbackQuery):
+    bot.answer_callback_query(c.id)
+    _open_settings(c.message.chat.id, c.message.message_id)

--- a/handlers/setup/A0_Overview.py
+++ b/handlers/setup/A0_Overview.py
@@ -2,8 +2,33 @@
 from telebot import types
 from .core import WIZ, edit, home_text
 
+from services.settings import get_settings
+from services.inventory import (
+    get_merch_inv, get_letters_inv, get_numbers_inv, get_templates_inv,
+)
+
 def render_home(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
+    if not d:
+        s = get_settings()
+        d.update({
+            "merch": s.get("merch", {}),
+            "features": s.get("features", {"letters": True, "numbers": True}),
+            "text_rules": s.get("text_rules", {
+                "allow_latin": True,
+                "allow_cyrillic": False,
+                "allow_space": True,
+                "max_text_len": 12,
+                "max_number": 99,
+            }),
+            "text_palette": s.get("text_palette", ["white", "black"]),
+            "text_colors": s.get("text_colors", {}),
+            "templates": s.get("templates", {}),
+            "_inv_merch": get_merch_inv(),
+            "_inv_letters": get_letters_inv(),
+            "_inv_numbers": get_numbers_inv(),
+            "_inv_tmpls": get_templates_inv(),
+        })
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Мерч", callback_data="setup:merch"),
            types.InlineKeyboardButton("2) Буквы", callback_data="setup:letters"))

--- a/handlers/setup/A8_TemplatesCollages.py
+++ b/handlers/setup/A8_TemplatesCollages.py
@@ -14,7 +14,10 @@ def ask_collages_or_next(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Готово ☑", callback_data="setup:tmpl_collages_done"))
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="setup:tmpl_collages_done"))
-    edit(chat_id, "Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).", kb)
+    cnt = len(d["templates"][mk].get("collages", []))
+    edit(chat_id,
+         f"Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).\nЗагружено коллажей: {cnt}",
+         kb)
     WIZ[chat_id]["stage"] = f"tmpl_collages:{mk}"
 
 def collages_done(chat_id: int):

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -1,16 +1,38 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+from utils.tg import color_name_ru
+
 
 def open_inventory_sizes(chat_id: int):
     WIZ[chat_id]["stage"] = "inv_sizes_home"
     d = WIZ[chat_id]["data"]
+    inv_merch = d.get("_inv_merch", {})
+    inv_letters = d.get("_inv_letters", {})
+    inv_numbers = d.get("_inv_numbers", {})
+    inv_tmpls = d.get("_inv_tmpls", {})
+    inv_on = bool(inv_merch or inv_letters or inv_numbers or inv_tmpls)
+    block = [
+        f"📦 Остатки [☑️ ВКЛ]{' ✅ — внесли' if inv_on else ' — не внесли'}",
+        f"├─ Размеры: {'✅ — внесли' if inv_merch else '— не внесли'}",
+        f"├─ Буквы: {'✅ — внесли' if inv_letters else '— не внесли'}",
+        f"├─ Цифры: {'✅ — внесли' if inv_numbers else '— не внесли'}",
+        f"└─ Макеты: {'✅ — внесли' if inv_tmpls else '— не внесли'}",
+    ]
+    block_txt = "\n".join(block)
     kb = types.InlineKeyboardMarkup(row_width=2)
     for mk, info in d.get("merch", {}).items():
-        kb.add(types.InlineKeyboardButton(info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"))
+        kb.add(
+            types.InlineKeyboardButton(
+                info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"
+            )
+        )
     kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters"))
-    edit(chat_id, "Шаг 4/4. 📦 Остатки — выберите Вид мерча.", kb)
+    edit(
+        chat_id,
+        f"Шаг 4/4. 📦 Остатки — выберите Вид мерча.\n<pre>{block_txt}</pre>",
+        kb,
+    )
 
 def open_colors(chat_id: int, mk: str):
     WIZ[chat_id]["stage"] = f"inv_sz_colors:{mk}"
@@ -18,6 +40,7 @@ def open_colors(chat_id: int, mk: str):
     kb = types.InlineKeyboardMarkup(row_width=3)
     for ck, ci in colors.items():
         kb.add(types.InlineKeyboardButton(ci["name_ru"], callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv_sizes_home"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_sizes_home"))
     edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b> — выберите цвет.", kb)
 
@@ -29,63 +52,31 @@ def open_sizes(chat_id: int, mk: str, ck: str):
     for sz in sizes:
         qty = inv.get(sz, 0)
         kb.add(types.InlineKeyboardButton(f"{sz}: {qty}", callback_data=f"setup:inv_sz_qty:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("➕ Применить ко всем размерам", callback_data=f"setup:inv_sz_apply_all:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("Задать число для всех", callback_data=f"setup:inv_sz_apply_all:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data=f"setup:inv_sizes_colors:{mk}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_colors:{mk}"))
-    edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}/{WIZ[chat_id]['data']['merch'][mk]['colors'][ck]['name_ru']}</b> — выберите размер или задайте число для всех.", kb)
+    merch_name = WIZ[chat_id]["data"]["merch"][mk]["name_ru"]
+    color_name = WIZ[chat_id]["data"]["merch"][mk]["colors"][ck]["name_ru"]
+    edit(
+        chat_id,
+        f"Остатки: <b>{merch_name}/{color_name}</b> — выберите размер или задайте число для всех.",
+        kb,
+    )
 
 def open_qty_spinner(chat_id: int, mk: str, ck: str, sz: str):
     WIZ[chat_id]["stage"] = f"inv_sz_qty:{mk}:{ck}:{sz}"
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
     cur = inv.get(sz, 0)
-    kb = types.InlineKeyboardMarkup(row_width=5)
-    kb.add(
-        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:-10"),
-        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:-1"),
-        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:1"),
-        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:10"),
-    )
-    kb.add(
-        types.InlineKeyboardButton("0", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:0"),
-        types.InlineKeyboardButton("1", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:1"),
-        types.InlineKeyboardButton("2", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:2"),
-        types.InlineKeyboardButton("5", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:5"),
-        types.InlineKeyboardButton("10", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:10"),
-    )
-    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_sz_save:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("⬅️ Назад к размерам", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
     edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\nТекущее: <b>{cur}</b>", kb)
 
-def adjust_qty(chat_id: int, mk: str, ck: str, sz: str, delta: int):
-    inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
-    cur = inv.get(sz, 0)
-    cur += delta
-    if cur < 0: cur = 0
-    inv[sz] = cur
-    open_qty_spinner(chat_id, mk, ck, sz)
-
-def set_qty(chat_id: int, mk: str, ck: str, sz: str, val: int):
-    inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
-    inv[sz] = max(0, val)
-    open_qty_spinner(chat_id, mk, ck, sz)
-
-def save_qty(chat_id: int, mk: str, ck: str, sz: str):
-    open_sizes(chat_id, mk, ck)
 
 def apply_all_sizes(chat_id: int, mk: str, ck: str):
-    WIZ[chat_id]["stage"] = f"inv_sz_apply_all:{mk}:{ck}"
-    kb = types.InlineKeyboardMarkup(row_width=5)
-    for val in (0,1,2,5,10,15,20,25,30):
-        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_sz_all_set:{mk}:{ck}:{val}"))
+    WIZ[chat_id]["stage"] = f"inv_sz_all:{mk}:{ck}"
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    edit(chat_id, f"Применить одно число ко всем размерам <b>{mk}/{ck}</b>.", kb)
-
-def set_all_sizes(chat_id: int, mk: str, ck: str, val: int):
-    inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
-    sizes = WIZ[chat_id]["data"]["merch"][mk]["sizes"]
-    for sz in sizes:
-        if inv.get(sz, 0) == 0:
-            inv[sz] = val
-    open_sizes(chat_id, mk, ck)
+    edit(chat_id, f"Введите одно число для всех размеров <b>{mk}/{ck}</b>.", kb)
 
 
 LAT = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -106,9 +97,9 @@ def open_inventory_letters(chat_id: int):
     pal = d.get("text_palette", [])
     kb = types.InlineKeyboardMarkup(row_width=2)
     for tc in pal:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"setup:inv_letters_chars:{tc}"))
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"setup:inv_letters_chars:{tc}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
-    kb.add(types.InlineKeyboardButton("✅ Пропустить", callback_data="setup:finish"))
+    kb.add(types.InlineKeyboardButton("✅ Готово → Цифры", callback_data="setup:inv_numbers"))
     edit(chat_id, "Остатки букв — выберите <b>цвет текста</b>.", kb)
 
 def open_letters_chars(chat_id: int, tc: str):
@@ -121,7 +112,7 @@ def open_letters_chars(chat_id: int, tc: str):
         kb.add(types.InlineKeyboardButton(f"{ch}: {qty}", callback_data=f"setup:inv_lt_qty:{tc}:{ch}"))
     kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_lt_apply_all:{tc}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
-    edit(chat_id, f"Остатки букв: <b>{tc}</b> — выберите букву.", kb)
+    edit(chat_id, f"Остатки букв: <b>{color_name_ru(tc)}</b> — выберите букву.", kb)
 
 def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
     WIZ[chat_id]["stage"] = f"inv_lt_qty:{tc}:{ch}"
@@ -143,7 +134,7 @@ def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
     )
     kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_lt_save:{tc}:{ch}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к буквам", callback_data=f"setup:inv_letters_chars:{tc}"))
-    edit(chat_id, f"Введите количество для <b>{ch}</b> цвета <b>{tc}</b>:\nТекущее: <b>{cur}</b>", kb)
+    edit(chat_id, f"Введите количество для <b>{ch}</b> цвета <b>{color_name_ru(tc)}</b>:\nТекущее: <b>{cur}</b>", kb)
 
 def adjust_letter_qty(chat_id: int, tc: str, ch: str, delta: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
@@ -167,7 +158,7 @@ def apply_all_letters(chat_id: int, tc: str):
     for val in (0,1,2,5,10,15,20,25,30):
         kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_lt_all_set:{tc}:{val}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_letters_chars:{tc}"))
-    edit(chat_id, f"Применить одно число ко всем буквам <b>{tc}</b>.", kb)
+    edit(chat_id, f"Применить одно число ко всем буквам <b>{color_name_ru(tc)}</b>.", kb)
 
 def set_all_letters(chat_id: int, tc: str, val: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
@@ -175,3 +166,166 @@ def set_all_letters(chat_id: int, tc: str, val: int):
         if inv.get(ch, 0) == 0:
             inv[ch] = val
     open_letters_chars(chat_id, tc)
+
+
+# --------- numbers inventory ----------
+DIGITS = list("0123456789")
+
+def open_inventory_numbers(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_numbers_home"
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for tc in pal:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"setup:inv_numbers_digits:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
+    kb.add(types.InlineKeyboardButton("✅ Готово → Макеты", callback_data="setup:inv_templates"))
+    edit(chat_id, "Остатки цифр — выберите <b>цвет цифр</b>.", kb)
+
+def open_numbers_digits(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_digits:{tc}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    kb = types.InlineKeyboardMarkup(row_width=6)
+    for dg in DIGITS:
+        qty = inv.get(dg, 0)
+        kb.add(types.InlineKeyboardButton(f"{dg}: {qty}", callback_data=f"setup:inv_nb_qty:{tc}:{dg}"))
+    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_nb_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_numbers"))
+    edit(chat_id, f"Остатки цифр: <b>{color_name_ru(tc)}</b> — выберите цифру.", kb)
+
+def open_number_qty_spinner(chat_id: int, tc: str, dg: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_qty:{tc}:{dg}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    cur = inv.get(dg, 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_nb_adj:{tc}:{dg}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_nb_adj:{tc}:{dg}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_nb_set:{tc}:{dg}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_nb_set:{tc}:{dg}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_nb_set:{tc}:{dg}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_nb_set:{tc}:{dg}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_nb_set:{tc}:{dg}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_nb_save:{tc}:{dg}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к цифрам", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(chat_id, f"Введите количество для цифры <b>{dg}</b> цвета <b>{color_name_ru(tc)}</b>:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_number_qty(chat_id: int, tc: str, dg: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    cur = inv.get(dg, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[dg] = cur
+    open_number_qty_spinner(chat_id, tc, dg)
+
+def set_number_qty(chat_id: int, tc: str, dg: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    inv[dg] = max(0, val)
+    open_number_qty_spinner(chat_id, tc, dg)
+
+def save_number_qty(chat_id: int, tc: str, dg: str):
+    open_numbers_digits(chat_id, tc)
+
+def apply_all_numbers(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_apply_all:{tc}"
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for val in (0,1,2,5,10,15,20,25,30):
+        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_nb_all_set:{tc}:{val}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(chat_id, f"Применить одно число ко всем цифрам <b>{color_name_ru(tc)}</b>.", kb)
+
+def set_all_numbers(chat_id: int, tc: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    for dg in DIGITS:
+        if inv.get(dg, 0) == 0:
+            inv[dg] = val
+    open_numbers_digits(chat_id, tc)
+
+
+# --------- templates inventory ----------
+def open_inventory_templates(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_tmpls_home"
+    d = WIZ[chat_id]["data"]
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    for mk, tinfo in d.get("templates", {}).items():
+        if tinfo.get("templates"):
+            name = d.get("merch", {}).get(mk, {}).get("name_ru", mk)
+            kb.add(types.InlineKeyboardButton(name, callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_numbers"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:finish"))
+    edit(chat_id, "Остатки макетов — выберите <b>вид мерча</b>.", kb)
+
+def open_template_numbers(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_nums:{mk}"
+    tpls = WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {})
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    nums_sorted = sorted(tpls.keys(), key=lambda x: (len(x), x))
+    kb = types.InlineKeyboardMarkup(row_width=4)
+    for num in nums_sorted:
+        qty = inv.get(num, {}).get("qty", 0)
+        kb.add(types.InlineKeyboardButton(f"{num}: {qty}", callback_data=f"setup:inv_tmpl_qty:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_tmpl_apply_all:{mk}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:finish"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_templates"))
+    edit(chat_id,
+         f"Остатки макетов — выберите номера макетов ({WIZ[chat_id]['data']['merch'][mk]['name_ru']}).",
+         kb)
+
+def open_template_qty_spinner(chat_id: int, mk: str, num: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_qty:{mk}:{num}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    cur = inv.setdefault(num, {}).get("qty", 0)
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-10"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-1"),
+        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:1"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:10"),
+    )
+    kb.add(
+        types.InlineKeyboardButton("0", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:0"),
+        types.InlineKeyboardButton("1", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:1"),
+        types.InlineKeyboardButton("2", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:2"),
+        types.InlineKeyboardButton("5", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:5"),
+        types.InlineKeyboardButton("10", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_tmpl_save:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к номерам", callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    edit(chat_id, f"Введите количество макетов <b>{num}</b> для {WIZ[chat_id]['data']['merch'][mk]['name_ru']}:\nТекущее: <b>{cur}</b>", kb)
+
+def adjust_template_qty(chat_id: int, mk: str, num: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    cur = inv.setdefault(num, {}).get("qty", 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[num]["qty"] = cur
+    open_template_qty_spinner(chat_id, mk, num)
+
+def set_template_qty(chat_id: int, mk: str, num: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    inv.setdefault(num, {})["qty"] = max(0, val)
+    open_template_qty_spinner(chat_id, mk, num)
+
+def save_template_qty(chat_id: int, mk: str, num: str):
+    open_template_numbers(chat_id, mk)
+
+def apply_all_templates(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_apply_all:{mk}"
+    kb = types.InlineKeyboardMarkup(row_width=5)
+    for val in (0,1,2,5,10,15,20,25,30):
+        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_tmpl_all_set:{mk}:{val}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    edit(chat_id, f"Применить одно число ко всем макетам <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b>.", kb)
+
+def set_all_templates(chat_id: int, mk: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    nums = WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {})
+    for num in nums.keys():
+        if inv.get(num, {}).get("qty", 0) == 0:
+            inv.setdefault(num, {})["qty"] = val
+    open_template_numbers(chat_id, mk)

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Tuple, List
 from telebot import types
 from telebot.apihelper import ApiTelegramException
 from bot import bot
+from utils.tg import color_name_ru
 
 # Состояние мастера по chat_id
 WIZ: Dict[int, Dict[str, Any]] = {}  # {"anchor_id", "stage", "data", "_sig"}
@@ -98,11 +99,12 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block: List[str] = []
-    block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
+    block.append(f"🛍 Мерч [{_on_off(merch_on)}]{' ✅' if merch_on else ''}")
     block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
     block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\n")
 
-    block.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
+    letters_on = feats.get('letters', False)
+    block.append(f"🔤 Буквы [{_on_off(letters_on)}]{' ✅' if letters_on else ''}")
     alph: List[str] = []
     if rules.get('allow_latin'): alph.append("LAT")
     if rules.get('allow_cyrillic'): alph.append("CYR")
@@ -112,21 +114,34 @@ def home_text(d: dict) -> str:
     block.append("├─ Пределы:")
     block.append(f"│ ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
     block.append(f"│ └─ Номер: ≤ {rules.get('max_number', '—')}")
-    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\n")
+    pal_str = (' | ').join(color_name_ru(c) for c in pal) if pal else '—'
+    block.append(f"└─ Палитра: {pal_str}\n")
 
-    block.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
+    numbers_on = feats.get('numbers', False)
+    block.append(f"🔢 Цифры [{_on_off(numbers_on)}]{' ✅' if numbers_on else ''}")
     block.append("└─ Соответствия:")
     block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\n")
 
-    block.append(f"🖼 Макеты [{_on_off(nums_set)}]")
+    block.append(f"🖼 Макеты [{_on_off(nums_set)}]{' ✅' if nums_set else ''}")
     block.append(f"├─ Номера: {'✅' if nums_set else '❌'}")
     block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\n")
 
-    block.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
-    block.append(f"├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
-    block.append(f"├─ Буквы: {'✅' if bool(inv_letters) else '❌'}")
-    block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
-    block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
+    inv_on = bool(inv_merch or inv_letters or inv_numbers or inv_tmpls)
+    block.append(
+        f"📦 Остатки [{_on_off(inv_on)}]{' ✅ — внесли' if inv_on else ' — не внесли'}"
+    )
+    block.append(
+        f"├─ Размеры: {'✅ — внесли' if bool(inv_merch) else '— не внесли'}"
+    )
+    block.append(
+        f"├─ Буквы: {'✅ — внесли' if bool(inv_letters) else '— не внесли'}"
+    )
+    block.append(
+        f"├─ Цифры: {'✅ — внесли' if bool(inv_numbers) else '— не внесли'}"
+    )
+    block.append(
+        f"└─ Макеты: {'✅ — внесли' if bool(inv_tmpls) else '— не внесли'}"
+    )
 
     body = "\n".join(block)
     return f"<b>🎛 МАСТЕР НАСТРОЙКИ</b>\n<pre>{body}</pre>"

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,15 +2,27 @@
 from telebot import types
 from bot import bot
 from services.settings import get_settings
+from utils.tg import set_chat_commands
 
 @bot.message_handler(commands=["start","help"])
 def start_cmd(message: types.Message):
+    chat_id = message.chat.id
+    set_chat_commands(bot, chat_id)
+
+    # сбрасываем незавершённые заказы
+    try:
+        from handlers.order_flow import ORD  # локальный импорт, чтобы избежать цикла
+        ORD.pop(chat_id, None)
+    except Exception:
+        pass
+
     s = get_settings()
     kb = types.InlineKeyboardMarkup(row_width=1)
     if not s.get("configured"):
         kb.add(types.InlineKeyboardButton("🔧 Запустить мастер настройки", callback_data="setup:init"))
         kb.add(types.InlineKeyboardButton("ℹ️ Привязка общего чата", callback_data="setup:bind_hint"))
-        bot.send_message(message.chat.id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
+        bot.send_message(chat_id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
     else:
-        kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="setup:init"))
-        bot.send_message(message.chat.id, "Бот настроен. Выберите действие:", reply_markup=kb)
+        kb.add(types.InlineKeyboardButton("🛒 Сделать заказ", callback_data="order:start"))
+        kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="settings_open"))
+        bot.send_message(chat_id, "Бот настроен. Выберите действие:", reply_markup=kb)

--- a/repositories/files.py
+++ b/repositories/files.py
@@ -11,9 +11,16 @@ import json
 import logging
 import os
 import tempfile
+import threading
 from typing import Any, Dict
 
 import config
+
+# In-memory cache for JSON files to minimise disk access.  A single
+# reentrant lock guards both cache lookups and file writes, ensuring that
+# concurrent threads do not read stale data or step on each other's writes.
+_CACHE: Dict[str, Dict[str, Any]] = {}
+_LOCK = threading.RLock()
 
 log = logging.getLogger(__name__)
 
@@ -37,15 +44,24 @@ def load_json(filename: str) -> Dict[str, Any]:
     """
 
     path = _path(filename)
-    if not os.path.exists(path):
-        return {}
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            text = f.read().strip()
-            return json.loads(text) if text else {}
-    except (OSError, json.JSONDecodeError) as err:
-        log.warning("Failed to load JSON from %s: %s", path, err)
-        return {}
+    with _LOCK:
+        if path in _CACHE:
+            # Return a copy so callers cannot accidentally mutate the cache
+            return dict(_CACHE[path])
+
+        if not os.path.exists(path):
+            _CACHE[path] = {}
+            return {}
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read().strip()
+                data = json.loads(text) if text else {}
+        except (OSError, json.JSONDecodeError) as err:
+            log.warning("Failed to load JSON from %s: %s", path, err)
+            data = {}
+
+        _CACHE[path] = data
+        return dict(data)
 
 def save_json(filename: str, data: Dict[str, Any]) -> None:
     """Persist *data* to *filename* atomically.
@@ -65,6 +81,9 @@ def save_json(filename: str, data: Dict[str, Any]) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
             json.dump(data, tmp_file, ensure_ascii=False, indent=2)
         os.replace(tmp_path, path)
+        with _LOCK:
+            # Store a copy to avoid external mutation of the cached object
+            _CACHE[path] = dict(data)
     except OSError as err:
         log.warning("Failed to write JSON to %s: %s", path, err)
         raise

--- a/router.py
+++ b/router.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, bind, order_flow, errors  # noqa: F401
+from handlers import start, bind, order_flow, settings, errors, debug  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 

--- a/utils/tg.py
+++ b/utils/tg.py
@@ -15,3 +15,40 @@ def safe_edit_message(bot: TeleBot, chat_id: int, message_id: int, text: str,
         bot.edit_message_text(text, chat_id, message_id, reply_markup=markup, parse_mode="HTML")
     except Exception:
         pass
+
+
+COLOR_NAMES_RU = {
+    "white": "Белый",
+    "black": "Чёрный",
+    "gold":  "Золотой",
+    "red":   "Красный",
+    "blue":  "Синий",
+    "green": "Зелёный",
+    "brown": "Коричневый",
+}
+
+
+def color_name_ru(key: str) -> str:
+    """Return Russian human-friendly name for a color key."""
+    return COLOR_NAMES_RU.get(key, key)
+
+
+def set_chat_commands(bot: TeleBot, chat_id: int) -> None:
+    """Configure the command menu for a specific chat based on its rights."""
+    from services.settings import get_admin_bind
+    import config
+
+    base_cmds = [
+        types.BotCommand("start", "Запуск"),
+        types.BotCommand("help", "Помощь"),
+        types.BotCommand("number", "Цвет цифр"),
+    ]
+
+    admin_chat, _ = get_admin_bind()
+    if chat_id in (admin_chat, getattr(config, "ADMIN_CHAT_ID", None)):
+        base_cmds.extend([
+            types.BotCommand("stock", "Остатки"),
+            types.BotCommand("bind_here", "Привязать чат"),
+        ])
+
+    bot.set_my_commands(base_cmds, scope=types.BotCommandScopeChat(chat_id))


### PR DESCRIPTION
## Summary
- cache JSON data with a thread-safe in-memory store to minimise disk access
- show inventory progress with explicit `✅ — внесли`/`— не внесли` markers and allow bulk size updates
- let coordinators pick templates with green toggling and warn early when letters or digits are short
- fix inventory menu rendering by prejoining lines before f-string interpolation

## Testing
- `python -m py_compile handlers/setup/core.py handlers/setup/A9_InventorySizes.py handlers/setup/router.py handlers/order_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d7b455b08324bcf8c18069209ffe