### PR TITLE
Add admin roles, layout dashboard, and JSON cache

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -2,9 +2,11 @@
 from telebot import types
 from bot import bot
 from services.settings import save_admin_bind
+from utils.tg import set_chat_commands
 
 @bot.message_handler(commands=["bind_here"])
 def bind_here_cmd(message: types.Message):
     thread_id = getattr(message, "message_thread_id", None)
     save_admin_bind(message.chat.id, thread_id)
+    set_chat_commands(bot, message.chat.id)
     bot.reply_to(message, "✅ Чат привязан.")

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.settings import (
+    is_admin,
+    is_superadmin,
+    is_authorized,
+    is_coordinator,
+    add_admin,
+    del_admin,
+    get_admins,
+    add_coordinator,
+    del_coordinator,
+    get_coordinators,
+    refresh_promo_members,
+    delete_layout,
+    SUPERADMINS,
+)
+
+
+@bot.message_handler(func=lambda m: not is_authorized(m.from_user.id))
+def _ignore_unauthorized(message: types.Message):
+    pass
+
+
+def _extract_uid(message: types.Message) -> int | None:
+    if message.reply_to_message:
+        return message.reply_to_message.from_user.id
+    parts = (message.text or "").split()
+    if len(parts) > 1:
+        try:
+            return int(parts[1])
+        except Exception:
+            return None
+    return None
+
+
+def _require_admin(message: types.Message) -> bool:
+    if not is_admin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return False
+    return True
+
+
+@bot.message_handler(commands=["stock"])
+def cmd_stock(message: types.Message):
+    if not _require_admin(message):
+        return
+    bot.send_message(message.chat.id, "ℹ️ Быстрая корректировка остатков пока не реализована.")
+
+
+@bot.message_handler(commands=["promo_test"])
+def cmd_promo(message: types.Message):
+    if not _require_admin(message):
+        return
+    bot.send_message(message.chat.id, "ℹ️ Топ пользователей по заказам недоступен.")
+
+
+@bot.message_handler(commands=["analytics"])
+def cmd_analytics(message: types.Message):
+    if not _require_admin(message):
+        return
+    bot.send_message(message.chat.id, "ℹ️ Аналитика ещё не реализована.")
+
+
+@bot.message_handler(commands=["settings"])
+def cmd_settings(message: types.Message):
+    bot.send_message(message.chat.id, "🔧 Настройки доступны через главное меню.")
+
+
+@bot.message_handler(commands=["admin"])
+def cmd_admin(message: types.Message):
+    if not _require_admin(message):
+        return
+    bot.send_message(message.chat.id, "Админка в разработке.")
+
+
+@bot.message_handler(commands=["admin_add"])
+def cmd_admin_add(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    add_admin(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} добавлен в ADMINS")
+
+
+@bot.message_handler(commands=["admin_del"])
+def cmd_admin_del(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    del_admin(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} удалён из ADMINS")
+
+
+@bot.message_handler(commands=["admin_list"])
+def cmd_admin_list(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    admins = ", ".join(map(str, get_admins())) or "—"
+    supers = ", ".join(map(str, SUPERADMINS))
+    bot.reply_to(message, f"SUPERADMINS: {supers}\nADMINS: {admins}")
+
+
+@bot.message_handler(commands=["coord_add"])
+def cmd_coord_add(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    add_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} добавлен в COORDINATORS")
+
+
+@bot.message_handler(commands=["coord_del"])
+def cmd_coord_del(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    del_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} удалён из COORDINATORS")
+
+
+@bot.message_handler(commands=["coord_list"])
+def cmd_coord_list(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    coords = ", ".join(map(str, get_coordinators())) or "—"
+    bot.reply_to(message, f"COORDINATORS: {coords}")
+
+
+@bot.message_handler(commands=["promo_refresh"])
+def cmd_promo_refresh(message: types.Message):
+    if not is_superadmin(message.from_user.id):
+        bot.reply_to(message, "❌ Недостаточно прав.")
+        return
+    refresh_promo_members(bot)
+    bot.reply_to(message, "🔄 Список PROMO обновлён")
+
+
+@bot.message_handler(commands=["layout_delete"])
+def cmd_layout_delete(message: types.Message):
+    if not _require_admin(message):
+        return
+    parts = (message.text or "").split()
+    if len(parts) < 2:
+        bot.reply_to(message, "Укажите номер макета")
+        return
+    layout_id = parts[1]
+    if delete_layout(layout_id):
+        bot.reply_to(message, f"✅ Макет {layout_id} удалён")
+    else:
+        bot.reply_to(message, f"❔ Макет {layout_id} не найден")
+
+
+@bot.message_handler(func=lambda m: m.text and m.text.startswith("/"))
+def cmd_unknown(message: types.Message):
+    bot.reply_to(message, "❔ Команда недоступна.")

--- a/handlers/debug.py
+++ b/handlers/debug.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+
+try:
+    from handlers.order_flow import ORD
+except Exception:
+    ORD = {}
+try:
+    from handlers.setup.core import WIZ
+except Exception:
+    WIZ = {}
+
+
+@bot.message_handler(func=lambda m: True, content_types=['text','photo','document','sticker','video','voice','location','contact'])
+def _log_unhandled_message(m: types.Message):
+    state = ORD.get(m.chat.id, {}).get('step') or WIZ.get(m.chat.id, {}).get('stage')
+    payload = m.text if m.content_type == 'text' else m.content_type
+    reason = "unknown command" if isinstance(payload, str) and payload.startswith('/') else "no handler"
+    print(f"[unhandled message] chat={m.chat.id} state={state} payload={payload} reason={reason}")
+
+
+@bot.callback_query_handler(func=lambda c: True)
+def _log_unhandled_callback(c: types.CallbackQuery):
+    state = ORD.get(c.message.chat.id, {}).get('step') or WIZ.get(c.message.chat.id, {}).get('stage')
+    print(f"[unhandled callback] chat={c.message.chat.id} state={state} data={c.data} reason=no handler")

--- a/handlers/order_flow.py
+++ b/handlers/order_flow.py
@@ -5,15 +5,36 @@ from telebot.apihelper import ApiTelegramException
 from bot import bot
 import config
 from services.settings import get_settings, get_admin_bind
+from services.orders import next_order_no
 from services.inventory import (
     get_merch_inv, get_letters_inv, get_numbers_inv, get_templates_inv,
     dec_size, dec_letter, dec_number, dec_template
 )
 from services.validators import validate_text, validate_number
-from utils.tg import safe_delete, safe_edit_message
+from utils.tg import safe_delete, safe_edit_message, color_name_ru
 
 # Временные заказы (по chat_id)
 ORD: dict[int, dict] = {}
+
+
+def _has_letters_stock(mk: str, ck: str) -> bool:
+    s = get_settings()
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_letters_inv()
+    for tc in tcolors:
+        if sum(inv.get(tc, {}).get("letters", {}).values()) > 0:
+            return True
+    return False
+
+
+def _has_numbers_stock(mk: str, ck: str) -> bool:
+    s = get_settings()
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_numbers_inv()
+    for tc in tcolors:
+        if sum(inv.get(tc, {}).get("numbers", {}).values()) > 0:
+            return True
+    return False
 
 def _admin_target():
     chat_id, thread_id = get_admin_bind()
@@ -37,140 +58,340 @@ def _send_to_admin_or_warn(user_chat_id: int, text: str) -> None:
         else:
             raise
 
+def _prompt_merch(chat_id: int):
+    s = get_settings()
+    inv = get_merch_inv()
+    avail = []
+    for mk, info in s.get("merch", {}).items():
+        colors = s.get("merch", {}).get(mk, {}).get("colors", {})
+        for ck in colors:
+            sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+            if any(q > 0 for q in sizes.values()):
+                avail.append((mk, info))
+                break
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступного мерча. Обновите остатки.")
+        return
+    if len(avail) == 1:
+        mk, info = avail[0]
+        ORD[chat_id]["merch"] = mk
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {info.get('name_ru', mk)} (других вариантов нет)")
+        _prompt_colors(chat_id, mk)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for mk, info in avail:
+        kb.add(types.InlineKeyboardButton(info.get("name_ru", mk), callback_data=f"order:m:{mk}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите вид мерча:", kb)
+
+
 @bot.callback_query_handler(func=lambda c: c.data == "order:start")
 def order_start(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    mid = c.message.message_id
     s = get_settings()
     if not s.get("configured"):
         bot.answer_callback_query(c.id)
-        bot.send_message(c.message.chat.id, "Бот не настроен. Нажмите /start и пройдите мастер.")
+        bot.send_message(chat_id, "Бот не настроен. Нажмите /start и пройдите мастер.")
         return
-    merch = s.get("merch", {})
+    ORD[chat_id] = {"mid": mid}
+    _prompt_merch(chat_id)
+
+
+def _prompt_colors(chat_id: int, mk: str):
+    s = get_settings()
+    inv = get_merch_inv()
+    colors = s.get("merch", {}).get(mk, {}).get("colors", {})
+    avail = []
+    for ck, info in colors.items():
+        sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+        if any(q > 0 for q in sizes.values()):
+            avail.append((ck, info.get("name_ru", ck)))
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных цветов. ⬅️ Назад")
+        return
+    if len(avail) == 1:
+        ck, name = avail[0]
+        ORD[chat_id]["color"] = ck
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {name} (других вариантов нет)")
+        _prompt_sizes(chat_id, mk, ck)
+        return
     kb = types.InlineKeyboardMarkup(row_width=2)
-    for mk, info in merch.items():
-        kb.add(types.InlineKeyboardButton(info.get("name_ru", mk), callback_data=f"order:m:{mk}"))
-    bot.edit_message_text("Выберите вид мерча:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    for ck, name in avail:
+        kb.add(types.InlineKeyboardButton(name, callback_data=f"order:c:{mk}:{ck}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет:", kb)
+
+
+def _prompt_sizes(chat_id: int, mk: str, ck: str):
+    inv = get_merch_inv()
+    sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
+    avail = [sz for sz, q in sizes.items() if q > 0]
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных размеров. ⬅️ Назад")
+        return
+    if len(avail) == 1:
+        sz = avail[0]
+        ORD[chat_id]["size"] = sz
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {sz} (других вариантов нет)")
+        _after_size(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for sz in avail:
+        kb.add(types.InlineKeyboardButton(sz, callback_data=f"order:s:{mk}:{ck}:{sz}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите размер:", kb)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:m:"))
 def order_choose_merch(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
     mk = c.data.split(":")[2]
-    s = get_settings()
-    inv = get_merch_inv()
-    # показать только цвета, у которых есть доступные размеры (>0)
-    kb = types.InlineKeyboardMarkup(row_width=2)
-    added = False
-    for ck, info in s.get("merch", {}).get(mk, {}).get("colors", {}).items():
-        sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
-        if any(q > 0 for q in sizes.values()):
-            kb.add(types.InlineKeyboardButton(info.get("name_ru", ck), callback_data=f"order:c:{mk}:{ck}"))
-            added = True
-    if not added:
-        bot.answer_callback_query(c.id)
-        bot.send_message(c.message.chat.id, "К сожалению, нет доступных цветов/размеров. Обновите остатки.")
-        return
-    ORD[c.message.chat.id] = {"merch": mk}
-    bot.edit_message_text("Выберите цвет:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    ORD.setdefault(chat_id, {})["merch"] = mk
+    _prompt_colors(chat_id, mk)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:c:"))
 def order_choose_color(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
     _, _, mk, ck = c.data.split(":")
-    inv = get_merch_inv()
-    sizes = inv.get(mk, {}).get(ck, {}).get("sizes", {})
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for sz, q in sizes.items():
-        if q > 0:
-            kb.add(types.InlineKeyboardButton(f"{sz}", callback_data=f"order:s:{mk}:{ck}:{sz}"))
-    ORD[c.message.chat.id].update({"color": ck})
-    bot.edit_message_text("Выберите размер:", c.message.chat.id, c.message.message_id, reply_markup=kb)
+    ORD.setdefault(chat_id, {})["color"] = ck
+    _prompt_sizes(chat_id, mk, ck)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:s:"))
 def order_choose_size(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    ORD[c.message.chat.id].update({"size": sz})
-    # спросим: нужен текст и/или номер?
-    kb = types.InlineKeyboardMarkup()
-    kb.add(types.InlineKeyboardButton("Текст", callback_data=f"order:text:{mk}:{ck}:{sz}"),
-           types.InlineKeyboardButton("Номер", callback_data=f"order:number:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("Без текста/номера", callback_data=f"order:skiptn:{mk}:{ck}:{sz}"))
-    bot.edit_message_text("Добавить надпись и/или номер?", c.message.chat.id, c.message.message_id, reply_markup=kb)
-
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:text:"))
-def order_text_choose_color(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    s = get_settings()
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    if not tcolors:
-        bot.answer_callback_query(c.id, "Нет допустимых цветов текста для этого цвета мерча.", show_alert=True)
-        return
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:textc:{mk}:{ck}:{sz}:{tc}"))
-    bot.edit_message_text("Выберите цвет текста:", c.message.chat.id, c.message.message_id, reply_markup=kb)
-
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:textc:"))
-def order_text_input(c: types.CallbackQuery):
-    _, _, mk, ck, sz, tc = c.data.split(":")
     chat_id = c.message.chat.id
-    ORD[chat_id]["text_color"] = tc
-    bot.edit_message_text("Введите текст (только буквы выбранных алфавитов и пробелы):", chat_id, c.message.message_id)
+    _, _, mk, ck, sz = c.data.split(":")
+    ORD.setdefault(chat_id, {})["size"] = sz
+    _after_size(chat_id)
+    
+def _after_size(chat_id: int):
+    s = get_settings()
+    feats = s.get("features", {})
+    mk = ORD[chat_id]["merch"]
+    ck = ORD[chat_id]["color"]
+    if feats.get("letters"):
+        if _has_letters_stock(mk, ck):
+            _prompt_text(chat_id)
+        else:
+            safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Шаг текста пропущен: буквы закончились.")
+            if feats.get("numbers") and _has_numbers_stock(mk, ck):
+                _prompt_number(chat_id)
+            elif feats.get("numbers") and not _has_numbers_stock(mk, ck):
+                safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Шаг номера пропущен: цифры закончились.")
+                _prompt_templates(chat_id)
+            else:
+                _prompt_templates(chat_id)
+    elif feats.get("numbers"):
+        if _has_numbers_stock(mk, ck):
+            _prompt_number(chat_id)
+        else:
+            safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Шаг номера пропущен: цифры закончились.")
+            _prompt_templates(chat_id)
+    else:
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Перейдём к выбору макетов.")
+        _prompt_templates(chat_id)
+
+
+def _prompt_text(chat_id: int):
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Введите текст (только буквы выбранных алфавитов и пробелы):")
     ORD[chat_id]["step"] = "text_wait"
+
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "text_wait")
 def order_text_set(m: types.Message):
-    ok, msg = validate_text(m.text.strip())
-    if not ok:
-        bot.reply_to(m, "⚠️ " + msg); return
-    ORD[m.chat.id]["text"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    bot.reply_to(m, "Текст принят. Использовать номер? /number или /skip")
-
-@bot.message_handler(commands=["number"])
-def cmd_number(m: types.Message):
     chat_id = m.chat.id
-    if chat_id not in ORD: return
-    s = get_settings()
-    mk = ORD[chat_id]["merch"]; ck = ORD[chat_id]["color"]
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    if not tcolors:
-        bot.reply_to(m, "Для выбранного цвета мерча нет допустимых цветов цифр."); return
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:numc:{mk}:{ck}:{ORD[chat_id]['size']}:{tc}"))
-    bot.send_message(chat_id, "Выберите цвет цифр:", reply_markup=kb)
+    mid = ORD.get(chat_id, {}).get("mid")
+    text = m.text.strip()
+    ok, msg = validate_text(text)
+    if not ok:
+        safe_edit_message(bot, chat_id, mid, f"⚠️ {msg}\n\nВведите текст (только буквы выбранных алфавитов и пробелы):")
+        safe_delete(bot, chat_id, m.message_id)
+        return
+    ORD[chat_id]["text"] = text
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_text_color(chat_id)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:number:"))
-def order_number_choose_color(c: types.CallbackQuery):
-    _, _, mk, ck, sz = c.data.split(":")
-    s = get_settings()
-    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
-    kb = types.InlineKeyboardMarkup(row_width=3)
-    for tc in tcolors:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"order:numc:{mk}:{ck}:{sz}:{tc}"))
-    bot.edit_message_text("Выберите цвет цифр:", c.message.chat.id, c.message.message_id, reply_markup=kb)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:numc:"))
-def order_number_input(c: types.CallbackQuery):
-    _, _, mk, ck, sz, tc = c.data.split(":")
+def _prompt_text_color(chat_id: int):
+    s = get_settings()
+    mk = ORD[chat_id]["merch"]
+    ck = ORD[chat_id]["color"]
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_letters_inv()
+    avail = []
+    for tc in tcolors:
+        if any(q > 0 for q in inv.get(tc, {}).get("letters", {}).values()):
+            avail.append(tc)
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        safe_edit_message(bot, chat_id, mid, "Нет доступных цветов текста.")
+        _prompt_number(chat_id)
+        return
+    if len(avail) == 1:
+        tc = avail[0]
+        ORD[chat_id]["text_color"] = tc
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {color_name_ru(tc)} (других вариантов нет)")
+        _prompt_number(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for tc in avail:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"order:textc:{tc}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет текста:", kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("order:textc:"))
+def order_text_color_cb(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    ORD[chat_id]["number_color"] = tc
-    bot.edit_message_text("Введите номер (0..N):", chat_id, c.message.message_id)
+    tc = c.data.split(":")[2]
+    ORD.setdefault(chat_id, {})["text_color"] = tc
+    letters_inv = get_letters_inv()
+    counts = {}
+    for ch in ORD[chat_id]["text"].replace(" ", "").upper():
+        counts[ch] = counts.get(ch, 0) + 1
+    miss = {ch: cnt for ch, cnt in counts.items()
+            if letters_inv.get(tc, {}).get("letters", {}).get(ch, 0) < cnt}
+    if miss:
+        msg_lines = ["⚠️ Недостаточно символов:"]
+        msg_lines.append("• Буквы: " + ", ".join(f"{k} ×{v}" for k, v in miss.items()))
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "\n".join(msg_lines))
+        _prompt_text(chat_id)
+        return
+    _prompt_number(chat_id)
+
+
+def _prompt_number(chat_id: int):
+    s = get_settings()
+    if not s.get("features", {}).get("numbers"):
+        _prompt_templates(chat_id)
+        return
+    mk = ORD[chat_id]["merch"]
+    ck = ORD[chat_id]["color"]
+    if not _has_numbers_stock(mk, ck):
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Шаг номера пропущен: цифры закончились.")
+        _prompt_templates(chat_id)
+        return
+    mid = ORD[chat_id]["mid"]
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("Без номера", callback_data="order:number_skip"))
+    safe_edit_message(bot, chat_id, mid, "Введите номер (0..N):", kb)
     ORD[chat_id]["step"] = "number_wait"
+
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "number_wait")
 def order_number_set(m: types.Message):
-    ok, msg = validate_number(m.text.strip())
+    chat_id = m.chat.id
+    mid = ORD.get(chat_id, {}).get("mid")
+    num = m.text.strip()
+    ok, msg = validate_number(num)
     if not ok:
-        bot.reply_to(m, "⚠️ " + msg); return
-    ORD[m.chat.id]["number"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _prompt_templates(m.chat.id)
+        safe_edit_message(bot, chat_id, mid, f"⚠️ {msg}\n\nВведите номер (0..N):")
+        safe_delete(bot, chat_id, m.message_id)
+        return
+    ORD[chat_id]["number"] = num
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_number_color(chat_id)
 
-@bot.callback_query_handler(func=lambda c: c.data.startswith("order:skiptn:"))
-def order_skip_text_number(c: types.CallbackQuery):
+
+@bot.callback_query_handler(func=lambda c: c.data == "order:number_skip")
+def order_number_skip(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    ORD[chat_id]["text"] = "Без текста"
-    ORD[chat_id]["number"] = "Без номера"
-    bot.edit_message_text("Перейдём к выбору макетов.", chat_id, c.message.message_id)
+    ORD.setdefault(chat_id, {})["number"] = "Без номера (-)"
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, "Перейдём к выбору макетов.")
     _prompt_templates(chat_id)
+
+
+def _prompt_number_color(chat_id: int):
+    s = get_settings()
+    mk = ORD[chat_id]["merch"]; ck = ORD[chat_id]["color"]
+    tcolors = s.get("text_colors", {}).get(mk, {}).get(ck, [])
+    inv = get_numbers_inv()
+    avail = []
+    for tc in tcolors:
+        if any(q > 0 for q in inv.get(tc, {}).get("numbers", {}).values()):
+            avail.append(tc)
+    mid = ORD[chat_id]["mid"]
+    if not avail:
+        _prompt_templates(chat_id)
+        return
+    if len(avail) == 1:
+        tc = avail[0]
+        ORD[chat_id]["number_color"] = tc
+        safe_edit_message(bot, chat_id, mid,
+                          f"Выбран автоматически: {color_name_ru(tc)} (других вариантов нет)")
+        _prompt_templates(chat_id)
+        return
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for tc in avail:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"order:numc:{tc}"))
+    safe_edit_message(bot, chat_id, mid, "Выберите цвет цифр:", kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("order:numc:"))
+def order_number_color_cb(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    tc = c.data.split(":")[2]
+    ORD.setdefault(chat_id, {})["number_color"] = tc
+    numbers_inv = get_numbers_inv()
+    counts = {}
+    for dg in ORD[chat_id]["number"]:
+        counts[dg] = counts.get(dg, 0) + 1
+    miss = {dg: cnt for dg, cnt in counts.items()
+            if numbers_inv.get(tc, {}).get("numbers", {}).get(dg, 0) < cnt}
+    if miss:
+        msg_lines = ["⚠️ Недостаточно символов:"]
+        msg_lines.append("• Цифры: " + ", ".join(f"{k} ×{v}" for k, v in miss.items()))
+        safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "\n".join(msg_lines))
+        _prompt_number(chat_id)
+        return
+    _prompt_templates(chat_id)
+
+def _render_tpl_step(chat_id: int):
+    avail = sorted(ORD[chat_id]["avail_tpls"])
+    sel = ORD[chat_id].get("selected_tpls", [])
+    page = ORD[chat_id].get("tpl_page", 0)
+    limit = ORD[chat_id].get("tpl_limit", len(avail))
+    indicator = get_settings()["layouts"].get("selected_indicator", "🟩")
+
+    start = page * 24
+    end = start + 24
+    page_items = avail[start:end]
+
+    row_size = 3
+    if any(len(x) >= 6 for x in page_items):
+        row_size = 2
+    elif all(len(x) <= 3 for x in page_items) and len(page_items) > 3:
+        row_size = 4
+
+    kb = types.InlineKeyboardMarkup(row_width=row_size)
+    rows = []
+    for n in page_items:
+        label = f"{indicator} {n}" if n in sel else n
+        rows.append(types.InlineKeyboardButton(label, callback_data=f"order:tpl:{n}"))
+    for i in range(0, len(rows), row_size):
+        kb.row(*rows[i:i+row_size])
+
+    nav = []
+    if page > 0:
+        nav.append(types.InlineKeyboardButton("‹ Назад", callback_data="order:tpl_page:-1"))
+    if end < len(avail):
+        nav.append(types.InlineKeyboardButton("Далее ›", callback_data="order:tpl_page:+1"))
+    if nav:
+        kb.row(*nav)
+
+    kb.row(types.InlineKeyboardButton("Дальше", callback_data="order:tpl_done"))
+    kb.row(types.InlineKeyboardButton("Очистить выбор макетов", callback_data="order:tpl_clear"))
+
+    joined = "·".join(sorted(sel)) if sel else "—"
+    text = f"🖼 Макеты ({len(sel)}/{limit}): {joined}"
+    safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], text, kb)
+
 
 def _prompt_templates(chat_id: int):
     s = get_settings(); invt = get_templates_inv()
@@ -183,51 +404,88 @@ def _prompt_templates(chat_id: int):
             qty = invt.get(mk, {}).get("templates", {}).get(num, {}).get("qty", 0)
             if qty > 0:
                 avail.append(num)
-    if tmpl_def.get("collages"):
-        for fid in tmpl_def["collages"][:5]:
-            try: bot.send_photo(chat_id, fid)
-            except Exception: pass
+    # remove old summary
+    safe_delete(bot, chat_id, ORD[chat_id]["mid"])
+    # send collages above summary
+    img_ids = []
+    colls = tmpl_def.get("collages", [])
+    if colls:
+        media = [types.InputMediaPhoto(fid) for fid in colls[:5]]
+        try:
+            if len(media) > 1:
+                msgs = bot.send_media_group(chat_id, media)
+            else:
+                msgs = [bot.send_photo(chat_id, media[0].media)]
+            img_ids = [m.message_id for m in msgs]
+        except Exception:
+            pass
+    ORD[chat_id]["tpl_img_ids"] = img_ids
     if not avail:
+        msg = bot.send_message(chat_id, "Доступных макетов нет.")
+        ORD[chat_id]["mid"] = msg.message_id
         _prompt_comment_phone(chat_id)
         return
-    kb = types.InlineKeyboardMarkup(row_width=4)
-    for n in sorted(avail):
-        kb.add(types.InlineKeyboardButton(n, callback_data=f"order:tpl:{n}"))
-    kb.add(types.InlineKeyboardButton("Готово", callback_data="order:tpl_done"),
-           types.InlineKeyboardButton("Без макета", callback_data="order:tpl_none"))
-    bot.send_message(chat_id, "Выберите номера макетов (можно несколько):", reply_markup=kb)
+    if len(avail) == 1:
+        ORD[chat_id]["templates"] = avail[0]
+        msg = bot.send_message(chat_id, f"Выбран автоматически: {avail[0]} (других вариантов нет)")
+        ORD[chat_id]["mid"] = msg.message_id
+        _prompt_comment_phone(chat_id)
+        return
+    msg = bot.send_message(chat_id, "...")
+    ORD[chat_id]["mid"] = msg.message_id
+    ORD[chat_id]["avail_tpls"] = avail
     ORD[chat_id]["selected_tpls"] = []
+    max_global = s.get("layouts", {}).get("max_per_order", len(avail))
+    ORD[chat_id]["tpl_limit"] = min(tmpl_def.get("limit", len(avail)), max_global)
+    ORD[chat_id]["tpl_page"] = 0
+    _render_tpl_step(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data.startswith("order:tpl"))
 def order_tpl_cb(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    if c.data == "order:tpl_none":
-        ORD[chat_id]["templates"] = "Без макета"
-        bot.answer_callback_query(c.id, "Без макета")
-        _prompt_comment_phone(chat_id)
-        return
     if c.data == "order:tpl_done":
         ORD[chat_id]["templates"] = ", ".join(sorted(set(ORD[chat_id].get("selected_tpls", [])))) or "Без макета"
         _prompt_comment_phone(chat_id)
+        return
+    if c.data == "order:tpl_clear":
+        ORD[chat_id]["selected_tpls"] = []
+        bot.answer_callback_query(c.id, "Очищено")
+        _render_tpl_step(chat_id)
+        return
+    if c.data.startswith("order:tpl_page"):
+        delta = int(c.data.split(":")[2])
+        ORD[chat_id]["tpl_page"] = max(0, ORD[chat_id].get("tpl_page", 0) + delta)
+        bot.answer_callback_query(c.id)
+        _render_tpl_step(chat_id)
         return
     n = c.data.split(":")[2]
     lst = ORD[chat_id].setdefault("selected_tpls", [])
     if n in lst:
         lst.remove(n); bot.answer_callback_query(c.id, f"Убрано: {n}")
     else:
-        lst.append(n); bot.answer_callback_query(c.id, f"Добавлено: {n}")
+        lim = ORD[chat_id].get("tpl_limit", len(ORD[chat_id].get("avail_tpls", [])))
+        if len(lst) < lim:
+            lst.append(n); bot.answer_callback_query(c.id, f"Добавлено: {n}")
+        else:
+            bot.answer_callback_query(c.id, "Достигнут лимит")
+    _render_tpl_step(chat_id)
 
 def _prompt_comment_phone(chat_id: int):
+    for mid_old in ORD[chat_id].pop("tpl_img_ids", []):
+        safe_delete(bot, chat_id, mid_old)
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="order:skip_comment"))
-    bot.send_message(chat_id, "Добавить комментарий к заказу?", reply_markup=kb)
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Добавить комментарий к заказу?", kb)
     ORD[chat_id]["step"] = "comment_wait"
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "comment_wait")
 def order_comment_set(m: types.Message):
-    ORD[m.chat.id]["comment"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _prompt_phone(m.chat.id)
+    chat_id = m.chat.id
+    ORD[chat_id]["comment"] = m.text.strip()
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _prompt_phone(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:skip_comment")
 def order_skip_comment(c: types.CallbackQuery):
@@ -239,14 +497,17 @@ def order_skip_comment(c: types.CallbackQuery):
 def _prompt_phone(chat_id: int):
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="order:skip_phone"))
-    bot.send_message(chat_id, "Введите номер телефона (или пропустите):", reply_markup=kb)
+    mid = ORD[chat_id]["mid"]
+    safe_edit_message(bot, chat_id, mid, "Введите номер телефона (или пропустите):", kb)
     ORD[chat_id]["step"] = "phone_wait"
 
 @bot.message_handler(func=lambda m: ORD.get(m.chat.id, {}).get("step") == "phone_wait")
 def order_phone_set(m: types.Message):
-    ORD[m.chat.id]["phone"] = m.text.strip()
-    ORD[m.chat.id].pop("step", None)
-    _show_summary(m.chat.id)
+    chat_id = m.chat.id
+    ORD[chat_id]["phone"] = m.text.strip()
+    ORD[chat_id].pop("step", None)
+    safe_delete(bot, chat_id, m.message_id)
+    _show_summary(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:skip_phone")
 def order_skip_phone(c: types.CallbackQuery):
@@ -255,70 +516,243 @@ def order_skip_phone(c: types.CallbackQuery):
     bot.answer_callback_query(c.id)
     _show_summary(chat_id)
 
-def _show_summary(chat_id: int):
-    s = get_settings(); invm = get_merch_inv()
-    d = ORD[chat_id]
+def _final_kb() -> types.InlineKeyboardMarkup:
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="order:final"))
+    kb.add(types.InlineKeyboardButton("✍️ Редактировать", callback_data="order:edit"))
+    kb.add(types.InlineKeyboardButton("⛔️ Отменить", callback_data="order:confirm_no"))
+    return kb
+
+
+def _build_summary(d: dict, deficits: dict | None = None) -> str:
+    s = get_settings()
     merch_name = s["merch"][d["merch"]]["name_ru"]
     color_name = s["merch"][d["merch"]]["colors"][d["color"]]["name_ru"]
-    lines = [
-        "<b>Информация о заказе:</b>",
-        f"Мерч: {html.escape(merch_name)}",
-        f"Цвет: {html.escape(color_name)}",
-        f"Размер: {html.escape(d['size'])}",
-        f"Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(d.get('text_color','-'))})",
-        f"Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(d.get('number_color','-'))})",
-        f"Макеты: {html.escape(d.get('templates','Без макета'))}",
-    ]
+    lines = ["Информация о заказе:"]
+    line = f"Мерч: {merch_name}"
+    if deficits and deficits.get("merch"):
+        line += f" ⚠️ {deficits['merch']}"
+    lines.append(line)
+    line = f"Цвет: {color_name}"
+    if deficits and deficits.get("color"):
+        line += f" ⚠️ {deficits['color']}"
+    lines.append(line)
+    line = f"Размер: {d['size']}"
+    if deficits and deficits.get("size"):
+        line += f" ⚠️ {deficits['size']}"
+    lines.append(line)
+    text_val = d.get("text") or "Без текста (-)"
+    line = f"Текст: {text_val}"
+    if deficits and deficits.get("letters"):
+        miss = ", ".join(deficits["letters"])
+        word = "закончилась буква" if len(deficits["letters"]) == 1 else "закончились буквы"
+        line += f" ⚠️ {word}: {miss}"
+    lines.append(line)
+    num_val = d.get("number") or "Без номера (-)"
+    line = f"Номер: {num_val}"
+    if deficits and deficits.get("digits"):
+        miss = ", ".join(deficits["digits"])
+        word = "закончилась цифра" if len(deficits["digits"]) == 1 else "закончились цифры"
+        line += f" ⚠️ {word}: {miss}"
+    lines.append(line)
+    tpl_val = d.get("templates") or "Без макета"
+    line = f"Макеты: {tpl_val}"
+    if deficits and deficits.get("templates"):
+        miss = ", ".join(deficits["templates"])
+        word = "закончился макет" if len(deficits["templates"]) == 1 else "закончились макеты"
+        line += f" ⚠️ {word}: {miss}"
+    lines.append(line)
     if d.get("phone"):
-        lines.append(f"Телефон: {html.escape(d['phone'])}")
+        lines.append(f"Телефон: {d['phone']}")
     if d.get("comment"):
-        lines.append(f"Комментарий: {html.escape(d['comment'])}")
-    kb = types.InlineKeyboardMarkup()
-    kb.add(types.InlineKeyboardButton("Отправить в печать ✅", callback_data="order:confirm_yes"),
-           types.InlineKeyboardButton("Отмена", callback_data="order:confirm_no"))
-    bot.send_message(chat_id, "\n".join(lines), reply_markup=kb)
+        lines.append(f"Комментарий: {d['comment']}")
+    return "\n".join(lines)
+
+
+def _show_summary(chat_id: int, deficits: dict | None = None):
+    d = ORD[chat_id]
+    mid = d["mid"]
+    text = _build_summary(d, deficits)
+    safe_edit_message(bot, chat_id, mid, text, _final_kb())
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "order:edit")
+def order_edit_menu(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(types.InlineKeyboardButton("Изменить мерч", callback_data="order:edit:merch"))
+    kb.add(types.InlineKeyboardButton("Изменить цвет мерча", callback_data="order:edit:color"))
+    kb.add(types.InlineKeyboardButton("Изменить размер", callback_data="order:edit:size"))
+    kb.add(types.InlineKeyboardButton("Изменить текст", callback_data="order:edit:text"))
+    kb.add(types.InlineKeyboardButton("Изменить цвет текста", callback_data="order:edit:textc"))
+    kb.add(types.InlineKeyboardButton("Изменить номер", callback_data="order:edit:number"))
+    kb.add(types.InlineKeyboardButton("Изменить цвет цифр", callback_data="order:edit:numberc"))
+    kb.add(types.InlineKeyboardButton("Изменить макеты", callback_data="order:edit:tpl"))
+    kb.add(types.InlineKeyboardButton("Очистить макеты", callback_data="order:edit:tplclear"))
+    kb.add(types.InlineKeyboardButton("Вернуться к подтверждению", callback_data="order:edit:back"))
+    kb.add(types.InlineKeyboardButton("Отменить заказ", callback_data="order:confirm_no"))
+    safe_edit_message(bot, chat_id, ORD[chat_id]["mid"], "Редактирование заказа", kb)
+
+
+@bot.callback_query_handler(func=lambda c: c.data.startswith("order:edit:"))
+def order_edit_action(c: types.CallbackQuery):
+    chat_id = c.message.chat.id
+    action = c.data.split(":")[2]
+    d = ORD.setdefault(chat_id, {})
+    if action == "merch":
+        for key in ["merch", "color", "size"]:
+            d.pop(key, None)
+        _prompt_merch(chat_id)
+    elif action == "color":
+        for key in ["color", "size"]:
+            d.pop(key, None)
+        _prompt_colors(chat_id, d.get("merch"))
+    elif action == "size":
+        d.pop("size", None)
+        _prompt_sizes(chat_id, d.get("merch"), d.get("color"))
+    elif action == "text":
+        d.pop("text", None)
+        _prompt_text(chat_id)
+    elif action == "textc":
+        d.pop("text_color", None)
+        _prompt_text_color(chat_id)
+    elif action == "number":
+        d.pop("number", None)
+        _prompt_number(chat_id)
+    elif action == "numberc":
+        d.pop("number_color", None)
+        _prompt_number_color(chat_id)
+    elif action == "tpl":
+        d.pop("templates", None)
+        _prompt_templates(chat_id)
+    elif action == "tplclear":
+        d["templates"] = "Без макета"
+        _prompt_templates(chat_id)
+    elif action == "back":
+        _show_summary(chat_id)
 
 @bot.callback_query_handler(func=lambda c: c.data == "order:confirm_no")
 def order_confirm_no(c: types.CallbackQuery):
     chat_id = c.message.chat.id
-    bot.edit_message_text("🛑 Заказ отменён. /start — начать заново.", chat_id, c.message.message_id)
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, "🛑 Заказ отменён. /start — начать заново.")
+    ORD.pop(chat_id, None)
 
-@bot.callback_query_handler(func=lambda c: c.data == "order:confirm_yes")
-def order_confirm_yes(c: types.CallbackQuery):
+def _check_deficits(d: dict) -> dict:
+    deficits = {}
+    inv = get_merch_inv()
+    size_q = inv.get(d["merch"], {}).get(d["color"], {}).get("sizes", {}).get(d["size"], 0)
+    if size_q <= 0:
+        deficits["size"] = f"закончился {d['size']}"
+        color_sizes = inv.get(d["merch"], {}).get(d["color"], {}).get("sizes", {})
+        if not any(q > 0 for q in color_sizes.values()):
+            deficits["color"] = f"закончился цвет: {get_settings()['merch'][d['merch']]['colors'][d['color']]['name_ru']}"
+        merch_colors = inv.get(d["merch"], {})
+        if not any(any(q > 0 for q in merch_colors.get(ck, {}).get("sizes", {}).values()) for ck in merch_colors):
+            deficits["merch"] = f"закончился мерч: {get_settings()['merch'][d['merch']]['name_ru']}"
+    letters_inv = get_letters_inv()
+    if d.get("text") and d["text"] != "Без текста (-)":
+        counts = {}
+        for ch in d["text"].replace(" ", "").upper():
+            counts[ch] = counts.get(ch, 0) + 1
+        miss = [ch for ch, cnt in counts.items()
+                if letters_inv.get(d.get("text_color"), {}).get("letters", {}).get(ch, 0) < cnt]
+        if miss:
+            deficits["letters"] = sorted(set(miss))
+    numbers_inv = get_numbers_inv()
+    if d.get("number") and d["number"] != "Без номера (-)":
+        counts = {}
+        for ch in d["number"]:
+            counts[ch] = counts.get(ch, 0) + 1
+        miss = [ch for ch, cnt in counts.items()
+                if numbers_inv.get(d.get("number_color"), {}).get("numbers", {}).get(ch, 0) < cnt]
+        if miss:
+            deficits["digits"] = sorted(set(miss))
+    tpl_inv = get_templates_inv()
+    if d.get("templates") and d["templates"] != "Без макета":
+        miss = []
+        for num in d["templates"].split(","):
+            q = tpl_inv.get(d["merch"], {}).get("templates", {}).get(num.strip(), {}).get("qty", 0)
+            if q <= 0:
+                miss.append(num.strip())
+        if miss:
+            deficits["templates"] = sorted(set(miss))
+    return deficits
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "order:final")
+def order_finalize(c: types.CallbackQuery):
     chat_id = c.message.chat.id
     d = ORD.get(chat_id, {})
+    deficits = _check_deficits(d)
+    if deficits:
+        _show_summary(chat_id, deficits)
+        return
     s = get_settings()
     merch_name = s["merch"][d["merch"]]["name_ru"]
     color_name = s["merch"][d["merch"]]["colors"][d["color"]]["name_ru"]
-
-    final_text = (
-        f"✉️ <b>Заказ</b>\n"
-        "---------------------------\n"
-        f"🛍 Мерч: {html.escape(merch_name)}\n"
-        f"🎨 Цвет: {html.escape(color_name)}\n"
-        f"📐 Размер: {html.escape(d['size'])}\n"
-        f"📝 Текст: {html.escape(d.get('text','Без текста'))} ({html.escape(d.get('text_color','-'))})\n"
-        f"🔢 Номер: {html.escape(d.get('number','Без номера'))} ({html.escape(d.get('number_color','-'))})\n"
-        f"🖼 Макеты: {html.escape(d.get('templates','Без макета'))}\n"
+    order_no = next_order_no()
+    username = bot.get_me().username
+    text_val = d.get("text")
+    if text_val in (None, "Без текста (-)"):
+        text_val = ""
+    number_val = d.get("number")
+    if number_val in (None, "Без номера (-)"):
+        number_val = ""
+    text_color = color_name_ru(d.get("text_color", "-"))
+    number_color = color_name_ru(d.get("number_color", "-"))
+    tpl_disp = (
+        "·".join(d.get("templates", "").replace(",", " ").split())
+        if d.get("templates") and d["templates"] != "Без макета"
+        else "—"
     )
-    if d.get("comment"):
-        final_text += f"❗️ Комментарий: {html.escape(d['comment'])}\n"
-    if d.get("phone"):
-        final_text += f"📞 Телефон: {html.escape(d['phone'])}\n"
+    phone = d.get("phone") or ""
+    comment = d.get("comment") or ""
+
+    parts = [
+        f"🚀<a href=\"tg://user?id={chat_id}\">🛒</a> <b>ВАШ ЗАКАЗ #{order_no}</b> "
+        f"<a href=\"https://t.me/{username}\">🤖</a>🌟",
+        f"🛍 {html.escape(merch_name)} | Цвет: {html.escape(color_name)} | {html.escape(d['size'])}",
+    ]
+
+    if text_val or number_val:
+        if text_val and number_val:
+            color_disp = text_color if text_color == number_color else f"{text_color}/{number_color}"
+            parts.append(
+                f"📝 {html.escape(text_val)} | {html.escape(number_val)} | Цвет: {html.escape(color_disp)}"
+            )
+        elif text_val:
+            parts.append(
+                f"📝 {html.escape(text_val)} | Цвет: {html.escape(text_color)}"
+            )
+        elif number_val:
+            parts.append(
+                f"📝 {html.escape(number_val)} | Цвет: {html.escape(number_color)}"
+            )
+
+    parts.append(f"🖼 Макеты: {html.escape(tpl_disp)}")
+    if phone:
+        parts.append(f"📞 {html.escape(phone)}")
+    if comment:
+        parts.append(f"💬 ❗{html.escape(comment)}❗")
+
+    final_text = "\n".join(parts)
 
     # Списание остатков
     dec_size(d["merch"], d["color"], d["size"], 1)
-    if d.get("text") and d["text"] != "Без текста":
-        dec_letter(d.get("text_color",""), d["text"])
-    if d.get("number") and d["number"] != "Без номера":
-        dec_number(d.get("number_color",""), d["number"])
+    if d.get("text") and d["text"] not in (None, "Без текста (-)"):
+        dec_letter(d.get("text_color", ""), d["text"])
+    if d.get("number") and d["number"] not in (None, "Без номера (-)"):
+        dec_number(d.get("number_color", ""), d["number"])
     if d.get("templates") and d["templates"] != "Без макета":
         for num in d["templates"].split(","):
             dec_template(d["merch"], num.strip())
 
-    bot.edit_message_text(final_text, chat_id, c.message.message_id, parse_mode="HTML")
+    mid = ORD.get(chat_id, {}).get("mid", c.message.message_id)
+    safe_edit_message(bot, chat_id, mid, final_text, parse_mode="HTML")
     _send_to_admin_or_warn(chat_id, final_text)
 
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Сделать новый заказ", callback_data="order:start"))
     bot.send_message(chat_id, "✅ Заказ оформлен!", reply_markup=kb)
+    ORD.pop(chat_id, None)

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+
+from handlers.setup.A0_Overview import render_home
+from handlers.setup.core import ensure
+
+try:
+    from handlers.order_flow import ORD
+except Exception:
+    ORD = {}
+
+
+def _open_settings(chat_id: int, mid: int):
+    ORD.pop(chat_id, None)
+    ensure(chat_id, mid)
+    render_home(chat_id)
+
+
+@bot.message_handler(func=lambda m: (m.text or "").strip().lower() == "настройки")
+def settings_msg(m: types.Message):
+    _open_settings(m.chat.id, m.message_id)
+
+
+@bot.callback_query_handler(func=lambda c: c.data == "settings_open")
+def settings_cb(c: types.CallbackQuery):
+    bot.answer_callback_query(c.id)
+    _open_settings(c.message.chat.id, c.message.message_id)

--- a/handlers/setup/A0_Overview.py
+++ b/handlers/setup/A0_Overview.py
@@ -2,14 +2,39 @@
 from telebot import types
 from .core import WIZ, edit, home_text
 
+from services.settings import get_settings
+from services.inventory import (
+    get_merch_inv, get_letters_inv, get_numbers_inv, get_templates_inv,
+)
+
 def render_home(chat_id: int):
     d = WIZ[chat_id].setdefault("data", {})
+    if not d:
+        s = get_settings()
+        d.update({
+            "merch": s.get("merch", {}),
+            "features": s.get("features", {"letters": True, "numbers": True}),
+            "text_rules": s.get("text_rules", {
+                "allow_latin": True,
+                "allow_cyrillic": False,
+                "allow_space": True,
+                "max_text_len": 12,
+                "max_number": 99,
+            }),
+            "text_palette": s.get("text_palette", ["white", "black"]),
+            "text_colors": s.get("text_colors", {}),
+            "templates": s.get("templates", {}),
+            "_inv_merch": get_merch_inv(),
+            "_inv_letters": get_letters_inv(),
+            "_inv_numbers": get_numbers_inv(),
+            "_inv_tmpls": get_templates_inv(),
+        })
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Мерч", callback_data="setup:merch"),
            types.InlineKeyboardButton("2) Буквы", callback_data="setup:letters"))
     kb.add(types.InlineKeyboardButton("2.1) Соответствия", callback_data="setup:map_text_colors"),
            types.InlineKeyboardButton("3) Макеты", callback_data="setup:tmpls"))
     kb.add(types.InlineKeyboardButton("4) Остатки", callback_data="setup:inv"),
-           types.InlineKeyboardButton("Готово ☑", callback_data="setup:finish"))
+           types.InlineKeyboardButton("Готово ✅", callback_data="setup:finish"))
     edit(chat_id, home_text(d), kb)
     WIZ[chat_id]["stage"] = "home"

--- a/handlers/setup/A1_Merch.py
+++ b/handlers/setup/A1_Merch.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit, slugify, merch_tree
+from utils.tg import color_key_from_ru, register_color_name
 
 DEFAULT_MERCH  = [("tshirt","Футболки"),("shopper","Шопперы"),("mug","Кружки")]
 DEFAULT_COLORS = [("white","Белый"),("black","Чёрный"),("red","Красный"),("blue","Синий"),("green","Зелёный"),("brown","Коричневый")]
@@ -84,8 +85,11 @@ def ask_custom_color(chat_id: int, mk: str):
 def handle_custom_color(chat_id: int, mk: str, text: str):
     name = text.strip()
     colors = WIZ[chat_id]["data"]["merch"][mk].setdefault("colors", {})
-    key = slugify(name, used=list(colors.keys()))
+    used = list(colors.keys())
+    key = color_key_from_ru(name, used)
     colors[key] = {"name_ru": name}
+    WIZ[chat_id]["data"].setdefault("color_names", {})[key] = name
+    register_color_name(key, name)
     render_colors(chat_id, mk)
 
 def render_sizes(chat_id: int, mk: str):

--- a/handlers/setup/A2_Letters.py
+++ b/handlers/setup/A2_Letters.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+from utils.tg import color_name_ru
 
 def render_letters_hub(chat_id: int):
     d = WIZ[chat_id]["data"]
@@ -21,12 +22,12 @@ def render_letters_hub(chat_id: int):
         f"   ├─ <b>Статус:</b> {letters_status}\n"
         f"   ├─ <b>Алфавит:</b> {alphabet_line} ▸ \n"
         f"   ├─ <b>Пробел:</b> {space_line}\n"
-        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} симв\n\n"
+        f"   └─ <b>Макс. длина:</b> ≤{rules.get('max_text_len','—')} символов\n\n"
         "<b>✨ Цифры</b>\n"
         f"   ├─ <b>Статус:</b> {numbers_status}\n"
         f"   └─ <b>Макс. номер:</b> ≤{rules.get('max_number','—')}\n\n"
         "<b>🎨 Палитра цветов текста</b>\n"
-        f"   └─ {', '.join(pal) if pal else '—'}\n"
+        f"   └─ {', '.join(color_name_ru(c) for c in pal) if pal else '—'}\n"
         "</pre>"
     )
     kb = types.InlineKeyboardMarkup(row_width=2)
@@ -47,15 +48,15 @@ def render_limits_progress(chat_id: int):
     st = WIZ[chat_id]["data"].setdefault("_limits", {"len_ok": bool(d.get('max_text_len')), "num_ok": bool(d.get('max_number'))})
     text = (
         "<pre><b>Пределы ✏️</b>\n"
-        f"1) Длина текста: {'☑' if st.get('len_ok') else '☐'}  (текущ.: {d.get('max_text_len', '—')})\n"
-        f"2) Макс. номер:  {'☑' if st.get('num_ok') else '☐'}  (текущ.: {d.get('max_number', '—')})\n"
+        f"1) Длина текста: {'✅' if st.get('len_ok') else '—'}  (текущ.: {d.get('max_text_len', '—')})\n"
+        f"2) Макс. номер:  {'✅' if st.get('num_ok') else '—'}  (текущ.: {d.get('max_number', '—')})\n"
         "Выберите этап или укажите по порядку.\n</pre>"
     )
     kb = types.InlineKeyboardMarkup(row_width=2)
     kb.add(types.InlineKeyboardButton("1) Ввести длину текста", callback_data="setup:limits_edit:text_len"),
             types.InlineKeyboardButton("2) Ввести макс. номер", callback_data="setup:limits_edit:max_num"))
     if st.get("len_ok") and st.get("num_ok"):
-        kb.add(types.InlineKeyboardButton("Готово ☑", callback_data="setup:limits_done"))
+        kb.add(types.InlineKeyboardButton("Готово ✅", callback_data="setup:limits_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
     edit(chat_id, text, kb)
     WIZ[chat_id]["stage"] = "limits_progress"

--- a/handlers/setup/A5_MapTextColors.py
+++ b/handlers/setup/A5_MapTextColors.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+from utils.tg import color_name_ru
 
 
 def render_pair(chat_id: int, mk: str, ck: str) -> None:
@@ -10,25 +11,32 @@ def render_pair(chat_id: int, mk: str, ck: str) -> None:
     pal = d.get("text_palette", [])
     merch = d.get("merch", {})
     kb = types.InlineKeyboardMarkup(row_width=3)
-
     cur = set(d.setdefault("text_colors", {}).setdefault(mk, {}).setdefault(ck, []))
     for tc in pal:
-        mark = "✓" if tc in cur else "·"
+        mark = "✅" if tc in cur else "□"
         kb.add(
             types.InlineKeyboardButton(
-                f"{tc} {mark}", callback_data=f"setup:maptc_toggle:{mk}:{ck}:{tc}"
+                f"{mark} {color_name_ru(tc)}",
+                callback_data=f"setup:maptc_toggle:{mk}:{ck}:{tc}",
             )
         )
-    kb.add(types.InlineKeyboardButton("Далее →", callback_data="setup:maptc_next"))
+    kb.add(types.InlineKeyboardButton("Готово", callback_data="setup:maptc_next"))
+    kb.add(
+        types.InlineKeyboardButton("Сбросить выбор", callback_data=f"setup:maptc_reset:{mk}:{ck}")
+    )
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
 
     merch_name = merch[mk]["name_ru"]
     color_name = merch[mk]["colors"][ck]["name_ru"]
-    edit(
-        chat_id,
-        f"Шаг 2.1/4. {merch_name} / {color_name}: выберите допустимые <b>цвета букв/цифр</b> (можно несколько).",
-        kb,
-    )
+    lines = [
+        f"📍 Шаг 2.1 / 4 — Настройка палитры для {merch_name}",
+        f"👕 Вид мерча: {merch_name}",
+        f"🎨 Цвет товара: {color_name}",
+        "",
+        "Выберите допустимые цвета букв и цифр:",
+    ]
+    text = "\n".join(lines)
+    edit(chat_id, text, kb)
     WIZ[chat_id]["stage"] = "map_text_colors"
 
     # mark this pair as reviewed under current palette size
@@ -64,8 +72,9 @@ def render_next_pair(chat_id: int) -> None:
                 render_pair(chat_id, mk, ck)
                 return
 
+    kb.add(types.InlineKeyboardButton("Изменить настройки соответствий", callback_data="setup:maptc_edit"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:letters"))
-    edit(chat_id, "Соответствия заданы для всех цветов мерча. ☑", kb)
+    edit(chat_id, "Соответствия заданы для всех цветов мерча. ✅", kb)
     WIZ[chat_id]["stage"] = "map_text_colors"
 
 
@@ -79,5 +88,17 @@ def toggle_map(chat_id: int, mk: str, ck: str, tc: str) -> None:
     render_pair(chat_id, mk, ck)
 
 
+def reset_map(chat_id: int, mk: str, ck: str) -> None:
+    d = WIZ[chat_id]["data"].setdefault("text_colors", {})
+    d.setdefault(mk, {})[ck] = []
+    render_pair(chat_id, mk, ck)
+
+
 def next_pair(chat_id: int) -> None:
+    render_next_pair(chat_id)
+
+
+def edit_all(chat_id: int) -> None:
+    """Re-open the correspondence editor with existing values."""
+    WIZ[chat_id]["data"].pop("_maptc_seen", None)
     render_next_pair(chat_id)

--- a/handlers/setup/A6_TemplatesNumbers.py
+++ b/handlers/setup/A6_TemplatesNumbers.py
@@ -15,6 +15,8 @@ def render_prompt(chat_id: int):
     d = WIZ[chat_id]["data"]["templates"][mk]["templates"]
     existing = ", ".join(sorted(d.keys())) or "—"
     kb = types.InlineKeyboardMarkup()
+    for tid in sorted(d.keys()):
+        kb.add(types.InlineKeyboardButton(f"🗑 {tid}", callback_data=f"setup:tmpl_del:{tid}"))
     kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:tmpl_num_done"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
     edit(chat_id,
@@ -40,3 +42,11 @@ def handle_input(chat_id: int, text: str):
 def done(chat_id: int):
     from .A7_TemplatesColors import render_for_next_template
     render_for_next_template(chat_id)
+
+
+def delete_template(chat_id: int, tid: str) -> None:
+    mk = WIZ[chat_id]["data"].get("_tmpl_current_mk")
+    if not mk:
+        return
+    WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {}).pop(tid, None)
+    render_prompt(chat_id)

--- a/handlers/setup/A8_TemplatesCollages.py
+++ b/handlers/setup/A8_TemplatesCollages.py
@@ -7,16 +7,29 @@ def ask_collages_or_next(chat_id: int):
     d = WIZ[chat_id]["data"]
     has = [mk for mk, t in d.get("templates", {}).items() if t.get("templates")]
     if not has:
-        from .A9_InventorySizes import open_inventory_sizes
-        open_inventory_sizes(chat_id); return
+        from .A9_InventorySizes import open_inventory_home
+        open_inventory_home(chat_id); return
     mk = has[0]
     WIZ[chat_id]["data"]["_mk_collages"] = mk
     kb = types.InlineKeyboardMarkup()
-    kb.add(types.InlineKeyboardButton("Готово ☑", callback_data="setup:tmpl_collages_done"))
+    cnt = len(d["templates"][mk].get("collages", []))
+    if cnt:
+        kb.add(types.InlineKeyboardButton("🗑 Очистить", callback_data="setup:tmpl_coll_del"))
+    kb.add(types.InlineKeyboardButton("Готово ✅", callback_data="setup:tmpl_collages_done"))
     kb.add(types.InlineKeyboardButton("Пропустить", callback_data="setup:tmpl_collages_done"))
-    edit(chat_id, "Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).", kb)
+    edit(chat_id,
+         f"Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).\nЗагружено коллажей: {cnt}",
+         kb)
     WIZ[chat_id]["stage"] = f"tmpl_collages:{mk}"
 
 def collages_done(chat_id: int):
-    from .A9_InventorySizes import open_inventory_sizes
-    open_inventory_sizes(chat_id)
+    from .A9_InventorySizes import open_inventory_home
+    open_inventory_home(chat_id)
+
+
+def clear_collages(chat_id: int) -> None:
+    mk = WIZ[chat_id]["data"].get("_mk_collages")
+    if not mk:
+        return
+    WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).setdefault("collages", []).clear()
+    ask_collages_or_next(chat_id)

--- a/handlers/setup/A9_InventorySizes.py
+++ b/handlers/setup/A9_InventorySizes.py
@@ -1,16 +1,52 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from .core import WIZ, edit
+from utils.tg import color_name_ru
 
-def open_inventory_sizes(chat_id: int):
-    WIZ[chat_id]["stage"] = "inv_sizes_home"
+
+def open_inventory_home(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_home"
+    d = WIZ[chat_id]["data"]
+    inv_merch = d.get("_inv_merch", {})
+    inv_letters = d.get("_inv_letters", {})
+    inv_numbers = d.get("_inv_numbers", {})
+    inv_tmpls = d.get("_inv_tmpls", {})
+    inv_on = bool(inv_merch or inv_letters or inv_numbers or inv_tmpls)
+    block = [
+        f"📦 Остатки [✅ ВКЛ]{' ✅ — внесли' if inv_on else ' — не внесли'}",
+        f"├─ Размеры: {'✅ — внесли' if inv_merch else '— не внесли'}",
+        f"├─ Буквы: {'✅ — внесли' if inv_letters else '— не внесли'}",
+        f"├─ Цифры: {'✅ — внесли' if inv_numbers else '— не внесли'}",
+        f"└─ Макеты: {'✅ — внесли' if inv_tmpls else '— не внесли'}",
+    ]
+    block_txt = "\n".join(block)
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(types.InlineKeyboardButton("Размеры", callback_data="setup:inv_merch"))
+    kb.add(types.InlineKeyboardButton("Буквы", callback_data="setup:inv_letters"))
+    kb.add(types.InlineKeyboardButton("Цифры", callback_data="setup:inv_numbers"))
+    kb.add(types.InlineKeyboardButton("Макеты", callback_data="setup:inv_templates"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+    kb.add(types.InlineKeyboardButton("🏠 Главное меню", callback_data="setup:home"))
+    edit(
+        chat_id,
+        f"Шаг 4/4. 📦 Остатки — выберите Вид мерча.\n<pre>{block_txt}</pre>",
+        kb,
+    )
+
+
+def open_merch_list(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_merch"
     d = WIZ[chat_id]["data"]
     kb = types.InlineKeyboardMarkup(row_width=2)
     for mk, info in d.get("merch", {}).items():
-        kb.add(types.InlineKeyboardButton(info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"))
-    kb.add(types.InlineKeyboardButton("Готово → Буквы", callback_data="setup:inv_letters"))
-    edit(chat_id, "Шаг 4/4. 📦 Остатки — выберите Вид мерча.", kb)
+        kb.add(
+            types.InlineKeyboardButton(
+                info["name_ru"], callback_data=f"setup:inv_sizes_colors:{mk}"
+            )
+        )
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
+    edit(chat_id, "Остатки: выберите вид мерча.", kb)
 
 def open_colors(chat_id: int, mk: str):
     WIZ[chat_id]["stage"] = f"inv_sz_colors:{mk}"
@@ -18,7 +54,8 @@ def open_colors(chat_id: int, mk: str):
     kb = types.InlineKeyboardMarkup(row_width=3)
     for ck, ci in colors.items():
         kb.add(types.InlineKeyboardButton(ci["name_ru"], callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_sizes_home"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv_merch"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_merch"))
     edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b> — выберите цвет.", kb)
 
 def open_sizes(chat_id: int, mk: str, ck: str):
@@ -29,63 +66,68 @@ def open_sizes(chat_id: int, mk: str, ck: str):
     for sz in sizes:
         qty = inv.get(sz, 0)
         kb.add(types.InlineKeyboardButton(f"{sz}: {qty}", callback_data=f"setup:inv_sz_qty:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("➕ Применить ко всем размерам", callback_data=f"setup:inv_sz_apply_all:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("Задать число для всех", callback_data=f"setup:inv_sz_apply_all:{mk}:{ck}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data=f"setup:inv_sizes_colors:{mk}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_colors:{mk}"))
-    edit(chat_id, f"Остатки: <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}/{WIZ[chat_id]['data']['merch'][mk]['colors'][ck]['name_ru']}</b> — выберите размер или задайте число для всех.", kb)
+    merch_name = WIZ[chat_id]["data"]["merch"][mk]["name_ru"]
+    color_name = WIZ[chat_id]["data"]["merch"][mk]["colors"][ck]["name_ru"]
+    edit(
+        chat_id,
+        f"Остатки: <b>{merch_name}/{color_name}</b> — выберите размер или задайте число для всех.",
+        kb,
+    )
 
 def open_qty_spinner(chat_id: int, mk: str, ck: str, sz: str):
     WIZ[chat_id]["stage"] = f"inv_sz_qty:{mk}:{ck}:{sz}"
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
     cur = inv.get(sz, 0)
-    kb = types.InlineKeyboardMarkup(row_width=5)
+    kb = types.InlineKeyboardMarkup(row_width=3)
     kb.add(
         types.InlineKeyboardButton("−10", callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:-10"),
+        types.InlineKeyboardButton("−5",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:-5"),
         types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:-1"),
+    )
+    kb.add(types.InlineKeyboardButton("0", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:0"))
+    kb.add(
         types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:1"),
+        types.InlineKeyboardButton("+5",  callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:5"),
         types.InlineKeyboardButton("+10", callback_data=f"setup:inv_sz_adj:{mk}:{ck}:{sz}:10"),
     )
-    kb.add(
-        types.InlineKeyboardButton("0", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:0"),
-        types.InlineKeyboardButton("1", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:1"),
-        types.InlineKeyboardButton("2", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:2"),
-        types.InlineKeyboardButton("5", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:5"),
-        types.InlineKeyboardButton("10", callback_data=f"setup:inv_sz_set:{mk}:{ck}:{sz}:10"),
-    )
     kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_sz_save:{mk}:{ck}:{sz}"))
-    kb.add(types.InlineKeyboardButton("⬅️ Назад к размерам", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    edit(chat_id, f"Введите количество для <b>{mk}/{ck}/{sz}</b>:\nТекущее: <b>{cur}</b>", kb)
+    kb.add(types.InlineKeyboardButton("⬅️ Отмена", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
+    merch_name = WIZ[chat_id]["data"]["merch"][mk]["name_ru"]
+    color_name = WIZ[chat_id]["data"]["merch"][mk]["colors"][ck]["name_ru"]
+    edit(
+        chat_id,
+        f"Введите количество для Размер «{sz}», {merch_name} / {color_name}:\nТекущее: <b>{cur}</b>",
+        kb,
+    )
 
-def adjust_qty(chat_id: int, mk: str, ck: str, sz: str, delta: int):
+
+def adjust_size_qty(chat_id: int, mk: str, ck: str, sz: str, delta: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
-    cur = inv.get(sz, 0)
-    cur += delta
-    if cur < 0: cur = 0
+    cur = inv.get(sz, 0) + delta
+    if cur < 0:
+        cur = 0
     inv[sz] = cur
     open_qty_spinner(chat_id, mk, ck, sz)
 
-def set_qty(chat_id: int, mk: str, ck: str, sz: str, val: int):
+
+def set_size_qty(chat_id: int, mk: str, ck: str, sz: str, val: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
     inv[sz] = max(0, val)
     open_qty_spinner(chat_id, mk, ck, sz)
 
-def save_qty(chat_id: int, mk: str, ck: str, sz: str):
+
+def save_size_qty(chat_id: int, mk: str, ck: str, sz: str):
     open_sizes(chat_id, mk, ck)
+
 
 def apply_all_sizes(chat_id: int, mk: str, ck: str):
-    WIZ[chat_id]["stage"] = f"inv_sz_apply_all:{mk}:{ck}"
-    kb = types.InlineKeyboardMarkup(row_width=5)
-    for val in (0,1,2,5,10,15,20,25,30):
-        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_sz_all_set:{mk}:{ck}:{val}"))
+    WIZ[chat_id]["stage"] = f"inv_sz_all:{mk}:{ck}"
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_sizes_sizes:{mk}:{ck}"))
-    edit(chat_id, f"Применить одно число ко всем размерам <b>{mk}/{ck}</b>.", kb)
-
-def set_all_sizes(chat_id: int, mk: str, ck: str, val: int):
-    inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
-    sizes = WIZ[chat_id]["data"]["merch"][mk]["sizes"]
-    for sz in sizes:
-        if inv.get(sz, 0) == 0:
-            inv[sz] = val
-    open_sizes(chat_id, mk, ck)
+    edit(chat_id, f"Введите одно число для всех размеров <b>{mk}/{ck}</b>.", kb)
 
 
 LAT = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -106,22 +148,23 @@ def open_inventory_letters(chat_id: int):
     pal = d.get("text_palette", [])
     kb = types.InlineKeyboardMarkup(row_width=2)
     for tc in pal:
-        kb.add(types.InlineKeyboardButton(tc, callback_data=f"setup:inv_letters_chars:{tc}"))
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"setup:inv_letters_chars:{tc}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
-    kb.add(types.InlineKeyboardButton("✅ Пропустить", callback_data="setup:finish"))
     edit(chat_id, "Остатки букв — выберите <b>цвет текста</b>.", kb)
 
 def open_letters_chars(chat_id: int, tc: str):
     WIZ[chat_id]["stage"] = f"inv_lt_letters:{tc}"
     letters = _letters(chat_id)
     inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
-    kb = types.InlineKeyboardMarkup(row_width=6)
+    kb = types.InlineKeyboardMarkup(row_width=3)
     for ch in letters:
         qty = inv.get(ch, 0)
         kb.add(types.InlineKeyboardButton(f"{ch}: {qty}", callback_data=f"setup:inv_lt_qty:{tc}:{ch}"))
-    kb.add(types.InlineKeyboardButton("➕ Применить ко всем", callback_data=f"setup:inv_lt_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("Задать число для всех", callback_data=f"setup:inv_lt_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_letters"))
-    edit(chat_id, f"Остатки букв: <b>{tc}</b> — выберите букву.", kb)
+    edit(chat_id, f"Остатки букв: <b>{color_name_ru(tc)}</b> — выберите букву.", kb)
 
 def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
     WIZ[chat_id]["stage"] = f"inv_lt_qty:{tc}:{ch}"
@@ -130,20 +173,22 @@ def open_letter_qty_spinner(chat_id: int, tc: str, ch: str):
     kb = types.InlineKeyboardMarkup(row_width=5)
     kb.add(
         types.InlineKeyboardButton("−10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-10"),
+        types.InlineKeyboardButton("−5",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-5"),
         types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:-1"),
-        types.InlineKeyboardButton("+1",  callback_data=f"setup:inv_lt_adj:{tc}:{ch}:1"),
-        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:10"),
     )
+    kb.add(types.InlineKeyboardButton("0", callback_data=f"setup:inv_lt_set:{tc}:{ch}:0"))
     kb.add(
-        types.InlineKeyboardButton("0", callback_data=f"setup:inv_lt_set:{tc}:{ch}:0"),
-        types.InlineKeyboardButton("1", callback_data=f"setup:inv_lt_set:{tc}:{ch}:1"),
-        types.InlineKeyboardButton("2", callback_data=f"setup:inv_lt_set:{tc}:{ch}:2"),
-        types.InlineKeyboardButton("5", callback_data=f"setup:inv_lt_set:{tc}:{ch}:5"),
-        types.InlineKeyboardButton("10", callback_data=f"setup:inv_lt_set:{tc}:{ch}:10"),
+        types.InlineKeyboardButton("+1", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:1"),
+        types.InlineKeyboardButton("+5", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:5"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_lt_adj:{tc}:{ch}:10"),
     )
     kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_lt_save:{tc}:{ch}"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад к буквам", callback_data=f"setup:inv_letters_chars:{tc}"))
-    edit(chat_id, f"Введите количество для <b>{ch}</b> цвета <b>{tc}</b>:\nТекущее: <b>{cur}</b>", kb)
+    edit(
+        chat_id,
+        f"Введите количество для Буква «{ch}», цвет {color_name_ru(tc)}:\nТекущее: <b>{cur}</b>",
+        kb,
+    )
 
 def adjust_letter_qty(chat_id: int, tc: str, ch: str, delta: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
@@ -162,16 +207,178 @@ def save_letter_qty(chat_id: int, tc: str, ch: str):
     open_letters_chars(chat_id, tc)
 
 def apply_all_letters(chat_id: int, tc: str):
-    WIZ[chat_id]["stage"] = f"inv_lt_apply_all:{tc}"
-    kb = types.InlineKeyboardMarkup(row_width=5)
-    for val in (0,1,2,5,10,15,20,25,30):
-        kb.add(types.InlineKeyboardButton(str(val), callback_data=f"setup:inv_lt_all_set:{tc}:{val}"))
+    WIZ[chat_id]["stage"] = f"inv_lt_all:{tc}"
+    kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_letters_chars:{tc}"))
-    edit(chat_id, f"Применить одно число ко всем буквам <b>{tc}</b>.", kb)
+    edit(chat_id, f"Введите одно число для всех букв <b>{color_name_ru(tc)}</b>.", kb)
+
 
 def set_all_letters(chat_id: int, tc: str, val: int):
     inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
     for ch in _letters(chat_id):
-        if inv.get(ch, 0) == 0:
-            inv[ch] = val
+        inv[ch] = val
     open_letters_chars(chat_id, tc)
+
+
+# --------- numbers inventory ----------
+DIGITS = list("0123456789")
+
+def open_inventory_numbers(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_numbers_home"
+    d = WIZ[chat_id]["data"]
+    pal = d.get("text_palette", [])
+    kb = types.InlineKeyboardMarkup(row_width=2)
+    for tc in pal:
+        kb.add(types.InlineKeyboardButton(color_name_ru(tc), callback_data=f"setup:inv_numbers_digits:{tc}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
+    edit(chat_id, "Остатки цифр — выберите <b>цвет цифр</b>.", kb)
+
+def open_numbers_digits(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_digits:{tc}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    for dg in DIGITS:
+        qty = inv.get(dg, 0)
+        kb.add(types.InlineKeyboardButton(f"{dg}: {qty}", callback_data=f"setup:inv_nb_qty:{tc}:{dg}"))
+    kb.add(types.InlineKeyboardButton("Задать число для всех", callback_data=f"setup:inv_nb_apply_all:{tc}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_numbers"))
+    edit(chat_id, f"Остатки цифр: <b>{color_name_ru(tc)}</b> — выберите цифру.", kb)
+
+def open_number_qty_spinner(chat_id: int, tc: str, dg: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_qty:{tc}:{dg}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    cur = inv.get(dg, 0)
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:-10"),
+        types.InlineKeyboardButton("−5",  callback_data=f"setup:inv_nb_adj:{tc}:{dg}:-5"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_nb_adj:{tc}:{dg}:-1"),
+    )
+    kb.add(types.InlineKeyboardButton("0", callback_data=f"setup:inv_nb_set:{tc}:{dg}:0"))
+    kb.add(
+        types.InlineKeyboardButton("+1", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:1"),
+        types.InlineKeyboardButton("+5", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:5"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_nb_adj:{tc}:{dg}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_nb_save:{tc}:{dg}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к цифрам", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(
+        chat_id,
+        f"Введите количество для Цифра «{dg}», цвет {color_name_ru(tc)}:\nТекущее: <b>{cur}</b>",
+        kb,
+    )
+
+def adjust_number_qty(chat_id: int, tc: str, dg: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    cur = inv.get(dg, 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[dg] = cur
+    open_number_qty_spinner(chat_id, tc, dg)
+
+def set_number_qty(chat_id: int, tc: str, dg: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    inv[dg] = max(0, val)
+    open_number_qty_spinner(chat_id, tc, dg)
+
+def save_number_qty(chat_id: int, tc: str, dg: str):
+    open_numbers_digits(chat_id, tc)
+
+def apply_all_numbers(chat_id: int, tc: str):
+    WIZ[chat_id]["stage"] = f"inv_nb_all:{tc}"
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_numbers_digits:{tc}"))
+    edit(chat_id, f"Введите одно число для всех цифр <b>{color_name_ru(tc)}</b>.", kb)
+
+
+def set_all_numbers(chat_id: int, tc: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+    for dg in DIGITS:
+        inv[dg] = val
+    open_numbers_digits(chat_id, tc)
+
+
+# --------- templates inventory ----------
+def open_inventory_templates(chat_id: int):
+    WIZ[chat_id]["stage"] = "inv_tmpls_home"
+    d = WIZ[chat_id]["data"]
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    for mk, tinfo in d.get("templates", {}).items():
+        if tinfo.get("templates"):
+            name = d.get("merch", {}).get(mk, {}).get("name_ru", mk)
+            kb.add(types.InlineKeyboardButton(name, callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv"))
+    edit(chat_id, "Остатки макетов — выберите <b>вид мерча</b>.", kb)
+
+def open_template_numbers(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_nums:{mk}"
+    tpls = WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {})
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    nums_sorted = sorted(tpls.keys(), key=lambda x: (len(x), x))
+    kb = types.InlineKeyboardMarkup(row_width=4)
+    for num in nums_sorted:
+        qty = inv.get(num, {}).get("qty", 0)
+        kb.add(types.InlineKeyboardButton(f"{num}: {qty}", callback_data=f"setup:inv_tmpl_qty:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("Задать число для всех", callback_data=f"setup:inv_tmpl_apply_all:{mk}"))
+    kb.add(types.InlineKeyboardButton("✅ Готово", callback_data="setup:inv"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:inv_templates"))
+    edit(chat_id,
+         f"Остатки макетов — выберите номера макетов ({WIZ[chat_id]['data']['merch'][mk]['name_ru']}).",
+         kb)
+
+def open_template_qty_spinner(chat_id: int, mk: str, num: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_qty:{mk}:{num}"
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    cur = inv.setdefault(num, {}).get("qty", 0)
+    kb = types.InlineKeyboardMarkup(row_width=3)
+    kb.add(
+        types.InlineKeyboardButton("−10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-10"),
+        types.InlineKeyboardButton("−5",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-5"),
+        types.InlineKeyboardButton("−1",  callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:-1"),
+    )
+    kb.add(types.InlineKeyboardButton("0", callback_data=f"setup:inv_tmpl_set:{mk}:{num}:0"))
+    kb.add(
+        types.InlineKeyboardButton("+1", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:1"),
+        types.InlineKeyboardButton("+5", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:5"),
+        types.InlineKeyboardButton("+10", callback_data=f"setup:inv_tmpl_adj:{mk}:{num}:10"),
+    )
+    kb.add(types.InlineKeyboardButton("✅ Сохранить", callback_data=f"setup:inv_tmpl_save:{mk}:{num}"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад к номерам", callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    edit(
+        chat_id,
+        f"Введите количество макетов <b>{num}</b> для {WIZ[chat_id]['data']['merch'][mk]['name_ru']}:\nТекущее: <b>{cur}</b>",
+        kb,
+    )
+
+def adjust_template_qty(chat_id: int, mk: str, num: str, delta: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    cur = inv.setdefault(num, {}).get("qty", 0) + delta
+    if cur < 0:
+        cur = 0
+    inv[num]["qty"] = cur
+    open_template_qty_spinner(chat_id, mk, num)
+
+def set_template_qty(chat_id: int, mk: str, num: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    inv.setdefault(num, {})["qty"] = max(0, val)
+    open_template_qty_spinner(chat_id, mk, num)
+
+def save_template_qty(chat_id: int, mk: str, num: str):
+    open_template_numbers(chat_id, mk)
+
+def apply_all_templates(chat_id: int, mk: str):
+    WIZ[chat_id]["stage"] = f"inv_tmpl_all:{mk}"
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data=f"setup:inv_tmpl_nums:{mk}"))
+    edit(chat_id, f"Введите одно число ко всем макетам <b>{WIZ[chat_id]['data']['merch'][mk]['name_ru']}</b>.", kb)
+
+
+def set_all_templates(chat_id: int, mk: str, val: int):
+    inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+    nums = WIZ[chat_id]["data"].get("templates", {}).get(mk, {}).get("templates", {})
+    for num in nums.keys():
+        inv.setdefault(num, {})["qty"] = val
+    open_template_numbers(chat_id, mk)

--- a/handlers/setup/core.py
+++ b/handlers/setup/core.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Tuple, List
 from telebot import types
 from telebot.apihelper import ApiTelegramException
 from bot import bot
+from utils.tg import color_name_ru
 
 # Состояние мастера по chat_id
 WIZ: Dict[int, Dict[str, Any]] = {}  # {"anchor_id", "stage", "data", "_sig"}
@@ -55,7 +56,7 @@ def slugify(name: str, used: List[str]) -> str:
     return s
 
 def _on_off(ok: bool) -> str:
-    return "☑️ ВКЛ" if ok else "☐ ВЫКЛ"
+    return "✅ ВКЛ" if ok else "☐ ВЫКЛ"
 
 def merch_tree(data: dict) -> str:
     merch = data.get("merch", {})
@@ -98,35 +99,39 @@ def home_text(d: dict) -> str:
     inv_tmpls   = d.get("_inv_tmpls", {})   if nums_set else True
 
     block: List[str] = []
-    block.append(f"🛍 Мерч [{_on_off(merch_on)}]")
-    block.append(f"├─ Цвета: {'✅' if colors_ok else '❌'}")
-    block.append(f"└─ Размеры: {'✅' if sizes_ok else '❌'}\n")
+    block.append(f"🛍 Мерч [{_on_off(merch_on)}]  ")
+    block.append(f"   ├─ Цвета: {'✅' if colors_ok else '❌'}  ")
+    block.append(f"   └─ Размеры: {'✅' if sizes_ok else '❌'}  \n")
 
-    block.append(f"🔤 Буквы [{_on_off(feats.get('letters', False))}]")
+    letters_on = feats.get('letters', False)
+    block.append(f"🔤 Буквы [{_on_off(letters_on)}]  ")
     alph: List[str] = []
     if rules.get('allow_latin'): alph.append("LAT")
     if rules.get('allow_cyrillic'): alph.append("CYR")
     alph_str = "/".join(alph) if alph else "—"
-    block.append(f"├─ Алфавит: {alph_str} — ▸")
-    block.append(f"├─ Пробел: {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}")
-    block.append("├─ Пределы:")
-    block.append(f"│ ├─ Текст: ≤ {rules.get('max_text_len', '—')} симв")
-    block.append(f"│ └─ Номер: ≤ {rules.get('max_number', '—')}")
-    block.append(f"└─ Палитра: {(' | ').join(pal) if pal else '—'}\n")
+    block.append(f"   ├─ Алфавит: {alph_str} — ▸  ")
+    block.append(f"   ├─ Пробел: {'ДА ✔️' if rules.get('allow_space') else 'НЕТ ✖️'}  ")
+    block.append("   ├─ Пределы:  ")
+    block.append(f"   │   ├─ Текст: ≤ {rules.get('max_text_len', '—')} символов  ")
+    block.append(f"   │   └─ Номер: ≤ {rules.get('max_number', '—')}  ")
+    pal_str = (' | ').join(color_name_ru(c) for c in pal) if pal else '—'
+    block.append(f"   └─ Палитра: {pal_str}  \n")
 
-    block.append(f"🔢 Цифры [{_on_off(feats.get('numbers', False))}]")
-    block.append("└─ Соответствия:")
-    block.append(f"Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}\n")
+    numbers_on = feats.get('numbers', False)
+    block.append(f"🔢 Цифры [{_on_off(numbers_on)}]  ")
+    block.append("   └─ Соответствия:  ")
+    block.append(f"       Мерч/Цвет → Цвет текста {'✅' if mapping_ok else '❌'}  \n")
 
-    block.append(f"🖼 Макеты [{_on_off(nums_set)}]")
-    block.append(f"├─ Номера: {'✅' if nums_set else '❌'}")
-    block.append(f"└─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}\n")
+    block.append(f"🖼 Макеты [{_on_off(nums_set)}]  ")
+    block.append(f"   ├─ Номера: {'✅' if nums_set else '❌'}  ")
+    block.append(f"   └─ Коллажи: {coll_count} {'🟢' if coll_count else '🚫'}  \n")
 
-    block.append(f"📦 Остатки [{_on_off(bool(inv_merch))}]")
-    block.append(f"├─ Размеры: {'✅' if bool(inv_merch) else '❌'}")
-    block.append(f"├─ Буквы: {'✅' if bool(inv_letters) else '❌'}")
-    block.append(f"├─ Цифры: {'✅' if bool(inv_numbers) else '❌'}")
-    block.append(f"└─ Макеты: {'✅' if bool(inv_tmpls) else '❌'}")
+    inv_on = bool(inv_merch or inv_letters or inv_numbers or inv_tmpls)
+    block.append(f"📦 Остатки [{_on_off(inv_on)}]  ")
+    block.append(f"   ├─ Размеры: {'✅ — внесли' if bool(inv_merch) else '— не внесли'}  ")
+    block.append(f"   ├─ Буквы: {'✅ — внесли' if bool(inv_letters) else '— не внесли'}  ")
+    block.append(f"   ├─ Цифры: {'✅ — внесли' if bool(inv_numbers) else '— не внесли'}  ")
+    block.append(f"   └─ Макеты: {'✅ — внесли' if bool(inv_tmpls) else '— не внесли'}  ")
 
     body = "\n".join(block)
     return f"<b>🎛 МАСТЕР НАСТРОЙКИ</b>\n<pre>{body}</pre>"

--- a/handlers/setup/router.py
+++ b/handlers/setup/router.py
@@ -1,4 +1,3 @@
-\
 # -*- coding: utf-8 -*-
 from telebot import types
 from bot import bot
@@ -13,6 +12,71 @@ from . import A6_TemplatesNumbers as TNUM
 from . import A7_TemplatesColors  as TCOL
 from . import A8_TemplatesCollages as TCOLL
 from . import A9_InventorySizes   as INV
+from services.settings import get_settings
+
+
+def render_templates_home(chat_id: int) -> None:
+    data = WIZ[chat_id]["data"]
+    tmpl = data.get("templates", {})
+    inv_tmpls = data.get("_inv_tmpls", {})
+    has_nums = any(v.get("templates") for v in tmpl.values())
+    has_colors = any(
+        any(t.get("allowed_colors") for t in v.get("templates", {}).values())
+        for v in tmpl.values()
+    )
+    has_qty = bool(inv_tmpls)
+    has_imgs = any(v.get("collages") for v in tmpl.values())
+    layouts = data.setdefault("layouts", get_settings().get("layouts", {"max_per_order":0, "selected_indicator":"🟩"}))
+    max_per = layouts.get("max_per_order") or 0
+    indicator = layouts.get("selected_indicator", "🟩")
+
+    def _mark(flag: bool) -> str:
+        return "✅" if flag else "⚠️"
+
+    limit_line = f"[{_mark(max_per>0)}] Limit — {max_per if max_per>0 else 'not set'}"
+    img_line = f"[{_mark(has_imgs)}] Images" + ("" if has_imgs else " — none")
+
+    block = [
+        f"[{_mark(has_nums)}] Numbers            [{_mark(has_colors)}] Colors",
+        f"[{_mark(has_qty)}] Quantities         {img_line}",
+        limit_line,
+        f"🎯 Selected marker: {indicator}",
+        "Legend: ✅ done  ⚠️ fill later  ❌ blocking",
+    ]
+
+    kb = types.InlineKeyboardMarkup(row_width=1)
+    kb.add(types.InlineKeyboardButton("Numbers", callback_data="setup:tmpl_nums"))
+    kb.add(types.InlineKeyboardButton("Colors", callback_data="setup:tmpl_map"))
+    kb.add(types.InlineKeyboardButton("Quantities", callback_data="setup:tmpl_qty"))
+    kb.add(types.InlineKeyboardButton("Images", callback_data="setup:tmpl_collages"))
+    kb.add(types.InlineKeyboardButton("Limit", callback_data="setup:tmpl_limit"))
+    kb.add(types.InlineKeyboardButton("Selected marker", callback_data="setup:tmpl_indicator"))
+    kb.add(types.InlineKeyboardButton("Структура доступности", callback_data="setup:tmpl_tree"))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:home"))
+
+    edit(chat_id, "🧩 Step 3/4 — Layouts\n<pre>" + "\n".join(block) + "</pre>", kb)
+    WIZ[chat_id]["stage"] = "tmpls_home"
+
+
+def render_templates_tree(chat_id: int) -> None:
+    data = WIZ[chat_id]["data"]
+    merch = data.get("merch", {})
+    tmpl = data.get("templates", {})
+    lines = ["Merch"]
+    for mk, mi in merch.items():
+        lines.append(f"  • {mi.get('name_ru', mk)}")
+        for ck, ci in mi.get("colors", {}).items():
+            ids = []
+            t_scope = tmpl.get(mk, {}).get("templates", {})
+            for tid, tinfo in t_scope.items():
+                if ck in tinfo.get("allowed_colors", []):
+                    ids.append(tid)
+            if ids:
+                lines.append(f"    — {ci.get('name_ru', ck)}  — макеты: {', '.join(ids)}")
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+    edit(chat_id, "\n".join(lines), kb)
+    WIZ[chat_id]["stage"] = "tmpls_tree"
 
 @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("setup:"))
 def setup_router(c: types.CallbackQuery):
@@ -64,33 +128,54 @@ def setup_router(c: types.CallbackQuery):
     # --- Step 2.1: Map text colors per merch/color ---
     if cmd == "map_text_colors":       MAP.render_next_pair(chat_id); return
     if cmd == "maptc_toggle":          MAP.toggle_map(chat_id, rest[0], rest[1], rest[2]); return
+    if cmd == "maptc_reset":           MAP.reset_map(chat_id, rest[0], rest[1]); return
     if cmd == "maptc_next":            MAP.next_pair(chat_id); return
+    if cmd == "maptc_edit":            MAP.edit_all(chat_id); return
 
     # --- Step 3: Templates ---
-    if cmd == "tmpls":
+    if cmd == "tmpls":                 render_templates_home(chat_id); return
+    if cmd == "tmpl_nums":
         kb = types.InlineKeyboardMarkup(row_width=1)
         d = WIZ[chat_id]["data"]
         for mk, mi in d.get("merch", {}).items():
             kb.add(types.InlineKeyboardButton(mi['name_ru'], callback_data=f"setup:tmpl_nums_for:{mk}"))
-        kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:home"))
+        kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
         edit(chat_id, "Шаг 3/4. Выберите вид мерча для ввода номеров макетов.", kb)
         WIZ[chat_id]["stage"] = "tmpls_pick"; return
     if cmd == "tmpl_nums_for":         TNUM.start_for_merch(chat_id, rest[0]); return
-    if cmd == "tmpl_num_done":         TNUM.done(chat_id); return
+    if cmd == "tmpl_num_done":         render_templates_home(chat_id); return
+    if cmd == "tmpl_del":              TNUM.delete_template(chat_id, rest[0]); return
+    if cmd == "tmpl_map":              TCOL.render_for_next_template(chat_id); return
     if cmd == "tmpl_color_toggle":     TCOL.toggle_color(chat_id, rest[0], rest[1], rest[2]); return
     if cmd == "tmpl_color_next":       TCOL.next_template(chat_id, rest[0], rest[1]); return
-    if cmd == "tmpl_collages_done":    TCOLL.collages_done(chat_id); return
+    if cmd == "tmpl_qty":              INV.open_inventory_templates(chat_id); return
+    if cmd == "tmpl_collages":         TCOLL.ask_collages_or_next(chat_id); return
+    if cmd == "tmpl_collages_done":    render_templates_home(chat_id); return
+    if cmd == "tmpl_coll_del":         TCOLL.clear_collages(chat_id); return
+    if cmd == "tmpl_tree":             render_templates_tree(chat_id); return
+    if cmd == "tmpl_limit":
+        cur = WIZ[chat_id]["data"].setdefault("layouts", get_settings().get("layouts", {})).get("max_per_order", 3)
+        kb = types.InlineKeyboardMarkup()
+        kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+        edit(chat_id, f"Текущее ограничение макетов на заказ: {cur}\nВведите новое значение (≥1):", kb)
+        WIZ[chat_id]["stage"] = "tmpl_limit"; return
+    if cmd == "tmpl_indicator":
+        cur = WIZ[chat_id]["data"].setdefault("layouts", get_settings().get("layouts", {})).get("selected_indicator", "🟩")
+        kb = types.InlineKeyboardMarkup()
+        kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+        edit(chat_id, f"Текущий смайлик выбранного макета: {cur}\nПришлите новый символ:", kb)
+        WIZ[chat_id]["stage"] = "tmpl_indicator"; return
 
     # --- Step 4: Inventory ---
-    if cmd == "inv":                    INV.open_inventory_sizes(chat_id); return
+    if cmd == "inv":                    INV.open_inventory_home(chat_id); return
+    if cmd == "inv_merch":              INV.open_merch_list(chat_id); return
     if cmd == "inv_sizes_colors":       INV.open_colors(chat_id, rest[0]); return
     if cmd == "inv_sizes_sizes":        INV.open_sizes(chat_id, rest[0], rest[1]); return
     if cmd == "inv_sz_qty":             INV.open_qty_spinner(chat_id, rest[0], rest[1], rest[2]); return
-    if cmd == "inv_sz_adj":             INV.adjust_qty(chat_id, rest[0], rest[1], rest[2], int(rest[3])); return
-    if cmd == "inv_sz_set":             INV.set_qty(chat_id, rest[0], rest[1], rest[2], int(rest[3])); return
-    if cmd == "inv_sz_save":            INV.save_qty(chat_id, rest[0], rest[1], rest[2]); return
     if cmd == "inv_sz_apply_all":       INV.apply_all_sizes(chat_id, rest[0], rest[1]); return
-    if cmd == "inv_sz_all_set":         INV.set_all_sizes(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_sz_adj":             INV.adjust_size_qty(chat_id, rest[0], rest[1], rest[2], int(rest[3])); return
+    if cmd == "inv_sz_set":             INV.set_size_qty(chat_id, rest[0], rest[1], rest[2], int(rest[3])); return
+    if cmd == "inv_sz_save":            INV.save_size_qty(chat_id, rest[0], rest[1], rest[2]); return
     if cmd == "inv_letters":            INV.open_inventory_letters(chat_id); return
     if cmd == "inv_letters_chars":      INV.open_letters_chars(chat_id, rest[0]); return
     if cmd == "inv_lt_qty":             INV.open_letter_qty_spinner(chat_id, rest[0], rest[1]); return
@@ -98,7 +183,20 @@ def setup_router(c: types.CallbackQuery):
     if cmd == "inv_lt_set":             INV.set_letter_qty(chat_id, rest[0], rest[1], int(rest[2])); return
     if cmd == "inv_lt_save":            INV.save_letter_qty(chat_id, rest[0], rest[1]); return
     if cmd == "inv_lt_apply_all":       INV.apply_all_letters(chat_id, rest[0]); return
-    if cmd == "inv_lt_all_set":         INV.set_all_letters(chat_id, rest[0], int(rest[1])); return
+    if cmd == "inv_numbers":            INV.open_inventory_numbers(chat_id); return
+    if cmd == "inv_numbers_digits":     INV.open_numbers_digits(chat_id, rest[0]); return
+    if cmd == "inv_nb_qty":             INV.open_number_qty_spinner(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_nb_adj":             INV.adjust_number_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_nb_set":             INV.set_number_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_nb_save":            INV.save_number_qty(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_nb_apply_all":       INV.apply_all_numbers(chat_id, rest[0]); return
+    if cmd == "inv_templates":          INV.open_inventory_templates(chat_id); return
+    if cmd == "inv_tmpl_nums":          INV.open_template_numbers(chat_id, rest[0]); return
+    if cmd == "inv_tmpl_qty":           INV.open_template_qty_spinner(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_tmpl_adj":           INV.adjust_template_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_tmpl_set":           INV.set_template_qty(chat_id, rest[0], rest[1], int(rest[2])); return
+    if cmd == "inv_tmpl_save":          INV.save_template_qty(chat_id, rest[0], rest[1]); return
+    if cmd == "inv_tmpl_apply_all":     INV.apply_all_templates(chat_id, rest[0]); return
 
     # --- Finish ---
     if cmd == "finish":                 _finish(chat_id); return
@@ -114,6 +212,8 @@ def _finish(chat_id: int):
     settings["text_palette"] = tmp.get("text_palette", ["white","black"])
     settings["text_colors"]  = tmp.get("text_colors", {})
     settings["templates"]    = tmp.get("templates", {})
+    settings["color_names"]  = tmp.get("color_names", {})
+    settings["layouts"]      = tmp.get("layouts", settings.get("layouts", {}))
     save_settings(settings)
 
     from services.inventory import save_merch_inv, save_letters_inv, save_numbers_inv, save_templates_inv
@@ -122,7 +222,9 @@ def _finish(chat_id: int):
     save_numbers_inv(tmp.get("_inv_numbers", {}))
     save_templates_inv(tmp.get("_inv_tmpls", {}))
 
-    edit(chat_id, "Готово! ☑ Бот настроен и готов к приёму заказов. Нажмите /start.", None)
+    edit(chat_id,
+         "✅ Готово!\nБот настроен и готов к приёму заказов. \n\nЧто дальше?\n• Нажмите /start, чтобы открыть главное меню.\n• Используйте «Сделать заказ» — процесс быстрый и пошаговый.\n• Настройки можно менять в любой момент — они сохраняются.",
+         None)
     WIZ.pop(chat_id, None)
 
 # ----------- удаляем пользовательские сообщения и обрабатываем ввод ----------
@@ -154,7 +256,13 @@ def _during_setup(m: types.Message):
         d = WIZ[chat_id]["data"].setdefault("templates", {}).setdefault(mk, {"templates": {}, "collages": []})
         f_id = m.photo[-1].file_id
         col = d.setdefault("collages", [])
-        if len(col) < 10: col.append(f_id)
+        col.append(f_id)
+        kb = types.InlineKeyboardMarkup()
+        kb.add(types.InlineKeyboardButton("Готово ✅", callback_data="setup:tmpl_collages_done"))
+        kb.add(types.InlineKeyboardButton("Пропустить", callback_data="setup:tmpl_collages_done"))
+        edit(chat_id,
+             f"Шаг 3.3/4. Пришлите 1–5 изображений‑коллажей (со списком макетов).\nЗагружено коллажей: {len(col)}",
+             kb)
     # --- лимиты по шагам ---
     elif st == "limits_len" and text:
         try:
@@ -168,5 +276,84 @@ def _during_setup(m: types.Message):
             from .A2_Letters import set_limit_num; set_limit_num(chat_id, val)
         except Exception:
             from .A2_Letters import ask_limit_num; ask_limit_num(chat_id)
+    elif st.startswith("inv_sz_all:") and text:
+        mk, ck = st.split(":")[1:3]
+        try:
+            val = int(text); assert val >= 0
+            inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
+            for sz in WIZ[chat_id]["data"]["merch"][mk]["sizes"]:
+                inv[sz] = val
+            INV.open_sizes(chat_id, mk, ck)
+        except Exception:
+            INV.apply_all_sizes(chat_id, mk, ck)
+    elif st.startswith("inv_sz_qty:") and text:
+        mk, ck, sz = st.split(":")[1:4]
+        try:
+            val = int(text); assert val >= 0
+            inv = WIZ[chat_id]["data"].setdefault("_inv_merch", {}).setdefault(mk, {}).setdefault(ck, {}).setdefault("sizes", {})
+            inv[sz] = val
+            INV.open_sizes(chat_id, mk, ck)
+        except Exception:
+            INV.open_qty_spinner(chat_id, mk, ck, sz)
+    elif st.startswith("inv_lt_all:") and text:
+        tc = st.split(":")[1]
+        try:
+            val = int(text); assert val >= 0
+            INV.set_all_letters(chat_id, tc, val)
+        except Exception:
+            INV.apply_all_letters(chat_id, tc)
+    elif st.startswith("inv_lt_qty:") and text:
+        tc, ch = st.split(":")[1:3]
+        try:
+            val = int(text); assert val >= 0
+            inv = WIZ[chat_id]["data"].setdefault("_inv_letters", {}).setdefault(tc, {}).setdefault("letters", {})
+            inv[ch] = val
+            INV.open_letters_chars(chat_id, tc)
+        except Exception:
+            INV.open_letter_qty_spinner(chat_id, tc, ch)
+    elif st.startswith("inv_nb_all:") and text:
+        tc = st.split(":")[1]
+        try:
+            val = int(text); assert val >= 0
+            INV.set_all_numbers(chat_id, tc, val)
+        except Exception:
+            INV.apply_all_numbers(chat_id, tc)
+    elif st.startswith("inv_nb_qty:") and text:
+        tc, dg = st.split(":")[1:3]
+        try:
+            val = int(text); assert val >= 0
+            inv = WIZ[chat_id]["data"].setdefault("_inv_numbers", {}).setdefault(tc, {}).setdefault("numbers", {})
+            inv[dg] = val
+            INV.open_numbers_digits(chat_id, tc)
+        except Exception:
+            INV.open_number_qty_spinner(chat_id, tc, dg)
+    elif st.startswith("inv_tmpl_all:") and text:
+        mk = st.split(":")[1]
+        try:
+            val = int(text); assert val >= 0
+            INV.set_all_templates(chat_id, mk, val)
+        except Exception:
+            INV.apply_all_templates(chat_id, mk)
+    elif st.startswith("inv_tmpl_qty:") and text:
+        mk, num = st.split(":")[1:3]
+        try:
+            val = int(text); assert val >= 0
+            inv = WIZ[chat_id]["data"].setdefault("_inv_tmpls", {}).setdefault(mk, {}).setdefault("templates", {})
+            inv.setdefault(num, {})["qty"] = val
+            INV.open_template_numbers(chat_id, mk)
+        except Exception:
+            INV.open_template_qty_spinner(chat_id, mk, num)
+    elif st == "tmpl_limit" and text:
+        try:
+            val = int(text); assert val >= 1
+            WIZ[chat_id]["data"].setdefault("layouts", {}).update({"max_per_order": val})
+            render_templates_home(chat_id)
+        except Exception:
+            kb = types.InlineKeyboardMarkup()
+            kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+            edit(chat_id, "Введите целое число ≥1:", kb)
+    elif st == "tmpl_indicator" and text:
+        WIZ[chat_id]["data"].setdefault("layouts", {}).update({"selected_indicator": text.strip() or "🟩"})
+        render_templates_home(chat_id)
     # --- удаляем любое пользовательское сообщение ---
     _safe_del(chat_id, m.message_id)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -2,15 +2,40 @@
 from telebot import types
 from bot import bot
 from services.settings import get_settings
+from utils.tg import set_chat_commands
 
 @bot.message_handler(commands=["start","help"])
 def start_cmd(message: types.Message):
+    chat_id = message.chat.id
+    set_chat_commands(bot, chat_id)
+
+    # сбрасываем незавершённые заказы
+    try:
+        from handlers.order_flow import ORD  # локальный импорт, чтобы избежать цикла
+        ORD.pop(chat_id, None)
+    except Exception:
+        pass
+
     s = get_settings()
     kb = types.InlineKeyboardMarkup(row_width=1)
     if not s.get("configured"):
         kb.add(types.InlineKeyboardButton("🔧 Запустить мастер настройки", callback_data="setup:init"))
         kb.add(types.InlineKeyboardButton("ℹ️ Привязка общего чата", callback_data="setup:bind_hint"))
-        bot.send_message(message.chat.id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
+        bot.send_message(chat_id, "<b>Мастер настройки</b> — нажмите кнопку ниже 👇", reply_markup=kb, parse_mode="HTML")
     else:
-        kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="setup:init"))
-        bot.send_message(message.chat.id, "Бот настроен. Выберите действие:", reply_markup=kb)
+        kb.add(types.InlineKeyboardButton("🛒 Сделать заказ", callback_data="order:start"))
+        kb.add(types.InlineKeyboardButton("🔧 Настройки", callback_data="settings_open"))
+        bot.send_message(chat_id, "Бот настроен. Выберите действие:", reply_markup=kb)
+
+
+@bot.message_handler(commands=["order"])
+def order_cmd(message: types.Message):
+    chat_id = message.chat.id
+    s = get_settings()
+    if not s.get("configured"):
+        bot.send_message(chat_id, "Бот не настроен. Нажмите /start и пройдите мастер.")
+        return
+    from handlers.order_flow import ORD, _prompt_merch
+    msg = bot.send_message(chat_id, "...")
+    ORD[chat_id] = {"mid": msg.message_id}
+    _prompt_merch(chat_id)

--- a/router.py
+++ b/router.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, bind, order_flow, errors  # noqa: F401
+# Командные хендлеры импортируем раньше остальных, чтобы команды имели приоритет
+from handlers import commands, start, bind, order_flow, settings, errors, debug  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 

--- a/services/orders.py
+++ b/services/orders.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Helpers for issuing sequential order numbers."""
+from typing import Dict
+from repositories.files import load_json, save_json
+
+_SEQ_FILE = "order_seq.json"
+
+
+def next_order_no() -> int:
+    data: Dict[str, int] = load_json(_SEQ_FILE) or {"next": 1}
+    n = data.get("next", 1)
+    data["next"] = n + 1
+    save_json(_SEQ_FILE, data)
+    return n

--- a/services/settings.py
+++ b/services/settings.py
@@ -5,10 +5,14 @@ from repositories.files import load_json, save_json
 SETTINGS_FILE = "settings.json"
 ADMIN_BIND_FILE = "admin_chat.json"
 
+SUPERADMINS = [445075408]
+PROMO_GROUP_ID = None
+PROMO_MEMBERS: set[int] = set()
+
+
 def get_settings() -> Dict[str, Any]:
     data = load_json(SETTINGS_FILE)
     if not data:
-        # Базовая заготовка до настройки
         data = {
             "configured": False,
             "text_rules": {
@@ -16,20 +20,127 @@ def get_settings() -> Dict[str, Any]:
                 "allow_cyrillic": False,
                 "allow_space": True,
                 "max_text_len": 12,
-                "max_number": 99
+                "max_number": 99,
             },
-            "merch": {},           # {merch_key: {name_ru, colors:{color_key:{name_ru}}, sizes:[...] } }
-            "text_colors": {},     # {merch_key:{color_key:[text_color,...]}, "palette":[...]}
-            "templates": {}        # {merch_key:{templates:{num:{allowed_colors:[...] }}, collages:[file_id,...]}}
+            "merch": {},
+            "text_colors": {},
+            "templates": {},
+            "color_names": {},
+            "layouts": {
+                "max_per_order": 3,
+                "selected_indicator": "🟩",
+            },
+            "admins": [],
+            "coordinators": [],
         }
+    else:
+        data.setdefault("color_names", {})
+        data.setdefault("layouts", {})
+        data.setdefault("admins", [])
+        data.setdefault("coordinators", [])
+        data["layouts"].setdefault("max_per_order", 3)
+        data["layouts"].setdefault("selected_indicator", "🟩")
     return data
+
 
 def save_settings(data: Dict[str, Any]) -> None:
     save_json(SETTINGS_FILE, data)
+
 
 def get_admin_bind() -> Tuple[Any, Any]:
     b = load_json(ADMIN_BIND_FILE)
     return (b.get("chat_id"), b.get("thread_id")) if b else (None, None)
 
+
 def save_admin_bind(chat_id, thread_id=None) -> None:
     save_json(ADMIN_BIND_FILE, {"chat_id": chat_id, "thread_id": thread_id})
+
+
+def get_admins() -> List[int]:
+    return get_settings().get("admins", [])
+
+
+def get_coordinators() -> List[int]:
+    return get_settings().get("coordinators", [])
+
+
+def add_admin(user_id: int) -> None:
+    data = get_settings()
+    admins = data.setdefault("admins", [])
+    if user_id not in admins:
+        admins.append(user_id)
+        save_settings(data)
+
+
+def del_admin(user_id: int) -> None:
+    data = get_settings()
+    admins = data.setdefault("admins", [])
+    if user_id in admins:
+        admins.remove(user_id)
+        save_settings(data)
+
+
+def add_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id not in coords:
+        coords.append(user_id)
+        save_settings(data)
+
+
+def del_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id in coords:
+        coords.remove(user_id)
+        save_settings(data)
+
+
+def is_superadmin(user_id: int) -> bool:
+    return user_id in SUPERADMINS
+
+
+def is_admin(user_id: int) -> bool:
+    return user_id in SUPERADMINS or user_id in get_admins()
+
+
+def is_coordinator(user_id: int) -> bool:
+    return user_id in get_coordinators()
+
+
+def refresh_promo_members(bot) -> None:
+    global PROMO_MEMBERS
+    if PROMO_GROUP_ID is None:
+        PROMO_MEMBERS = set()
+        return
+    try:
+        members = bot.get_chat_administrators(PROMO_GROUP_ID)
+        PROMO_MEMBERS = {m.user.id for m in members}
+    except Exception:
+        PROMO_MEMBERS = set()
+
+
+def is_promo(user_id: int) -> bool:
+    return user_id in PROMO_MEMBERS
+
+
+def is_authorized(user_id: int) -> bool:
+    return (
+        is_superadmin(user_id)
+        or user_id in get_admins()
+        or is_coordinator(user_id)
+        or is_promo(user_id)
+    )
+
+
+def delete_layout(layout_id: str) -> bool:
+    data = get_settings()
+    found = False
+    for meta in data.get("templates", {}).values():
+        tpls = meta.get("templates", {})
+        if layout_id in tpls:
+            del tpls[layout_id]
+            found = True
+    if found:
+        save_settings(data)
+    return found

--- a/utils/tg.py
+++ b/utils/tg.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from telebot import TeleBot, types
+from typing import List
 
 def safe_delete(bot: TeleBot, chat_id: int, message_id: int | None) -> None:
     if not message_id:
@@ -9,9 +10,107 @@ def safe_delete(bot: TeleBot, chat_id: int, message_id: int | None) -> None:
     except Exception:
         pass
 
-def safe_edit_message(bot: TeleBot, chat_id: int, message_id: int, text: str,
-                      markup: types.InlineKeyboardMarkup | None = None) -> None:
+def safe_edit_message(
+    bot: TeleBot,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    markup: types.InlineKeyboardMarkup | None = None,
+    parse_mode: str | None = "HTML",
+) -> None:
     try:
-        bot.edit_message_text(text, chat_id, message_id, reply_markup=markup, parse_mode="HTML")
+        bot.edit_message_text(
+            text,
+            chat_id,
+            message_id,
+            reply_markup=markup,
+            parse_mode=parse_mode,
+        )
     except Exception:
         pass
+
+
+COLOR_NAMES_RU = {
+    "white": "Белый",
+    "black": "Чёрный",
+    "gold": "Золотой",
+    "silver": "Серебряный",
+    "red": "Красный",
+    "blue": "Синий",
+    "green": "Зелёный",
+    "yellow": "Жёлтый",
+    "purple": "Фиолетовый",
+    "orange": "Оранжевый",
+    "pink": "Розовый",
+    "turquoise": "Бирюзовый",
+    "maroon": "Бордовый",
+    "gray": "Серый",
+    "brown": "Коричневый",
+}
+
+COLOR_RU_TO_EN = {v: k for k, v in COLOR_NAMES_RU.items()}
+
+def _slugify(name: str, used: List[str]) -> str:
+    trans = {
+        'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'e', 'ж': 'zh', 'з': 'z', 'и': 'i', 'й': 'i',
+        'к': 'k', 'л': 'l', 'м': 'm', 'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u', 'ф': 'f',
+        'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sch', 'ъ': '', 'ы': 'y', 'ь': '', 'э': 'e', 'ю': 'yu', 'я': 'ya'
+    }
+    s = name.strip().lower()
+    s = "".join(trans.get(ch, ch) for ch in s)
+    import re
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-") or "item"
+    base = s
+    i = 2
+    while s in used:
+        s = f"{base}-{i}"
+        i += 1
+    return s
+
+
+def color_key_from_ru(name_ru: str, used: List[str]) -> str:
+    """Generate an english key for a russian color name, ensuring uniqueness."""
+    key = COLOR_RU_TO_EN.get(name_ru.strip())
+    if not key:
+        key = _slugify(name_ru, used)
+    base = key
+    i = 2
+    while key in used:
+        key = f"{base}-{i}"
+        i += 1
+    return key
+
+
+def register_color_name(key: str, name_ru: str) -> None:
+    COLOR_NAMES_RU.setdefault(key, name_ru)
+
+
+def color_name_ru(key: str) -> str:
+    """Return Russian human-friendly name for a color key."""
+    from services.settings import get_settings
+    if key in COLOR_NAMES_RU:
+        return COLOR_NAMES_RU[key]
+    return get_settings().get("color_names", {}).get(key, key)
+
+
+def set_chat_commands(bot: TeleBot, chat_id: int) -> None:
+    """Configure the command menu for a specific chat based on its rights."""
+    from services.settings import get_admin_bind
+    import config
+
+    cmds = [
+        types.BotCommand("start", "Главное меню"),
+        types.BotCommand("order", "Сделать заказ"),
+        types.BotCommand("settings", "Настройки"),
+        types.BotCommand("admin", "Админка"),
+        types.BotCommand("stock", "Остатки"),
+        types.BotCommand("promo_test", "Топ пользователей"),
+        types.BotCommand("analytics", "Аналитика"),
+    ]
+
+    # Админам добавляем возможность привязки чата
+    admin_chat, _ = get_admin_bind()
+    if chat_id in (admin_chat, getattr(config, "ADMIN_CHAT_ID", None)):
+        cmds.append(types.BotCommand("bind_here", "Привязать чат"))
+
+    bot.set_my_commands(cmds, scope=types.BotCommandScopeChat(chat_id))


### PR DESCRIPTION
## Summary
- Minimize disk I/O by caching JSON files with a thread-safe in-memory store
- Serve cached data on reads and sync the cache after atomic writes

## Testing
- `python -m py_compile router.py handlers/setup/router.py handlers/order_flow.py repositories/files.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d7b455b08324bcf8c18069209ffe