### PR TITLE
feat: add role-based gating and diagnostics

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -7,6 +7,12 @@ from services.settings import (
     add_admin,
     del_admin,
     get_admins,
+    add_coordinator,
+    del_coordinator,
+    get_coordinators,
+    refresh_promo_cache,
+    get_roles,
+    is_authorized,
     SUPERADMINS,
 )
 
@@ -99,6 +105,56 @@ def cmd_admin_list(message: types.Message):
     bot.reply_to(message, f"SUPERADMINS: {supers}\nADMINS: {admins}")
 
 
+@bot.message_handler(commands=["coord_add"])
+def cmd_coord_add(message: types.Message):
+    if not _require_admin(message):
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    add_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} добавлен в COORDINATORS")
+
+
+@bot.message_handler(commands=["coord_del"])
+def cmd_coord_del(message: types.Message):
+    if not _require_admin(message):
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    del_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} удалён из COORDINATORS")
+
+
+@bot.message_handler(commands=["coord_list"])
+def cmd_coord_list(message: types.Message):
+    if not _require_admin(message):
+        return
+    coords = ", ".join(map(str, get_coordinators())) or "—"
+    bot.reply_to(message, f"COORDINATORS: {coords}")
+
+
+@bot.message_handler(commands=["promo_refresh"])
+def cmd_promo_refresh(message: types.Message):
+    if not _require_admin(message):
+        return
+    refresh_promo_cache(bot)
+    bot.reply_to(message, "🔄 PROMO обновлён")
+
+
+@bot.message_handler(commands=["whoami"])
+def cmd_whoami(message: types.Message):
+    uid = message.from_user.id
+    roles = get_roles(uid)
+    gated = not is_authorized(uid)
+    bot.reply_to(message, f"{{'id': {uid}, 'roles': {roles}, 'gated': {gated}}}")
+
+
 @bot.message_handler(func=lambda m: m.text and m.text.startswith("/"))
 def cmd_unknown(message: types.Message):
+    if not is_authorized(message.from_user.id):
+        return
     bot.reply_to(message, "❔ Команда недоступна на этом проекте")

--- a/handlers/gate.py
+++ b/handlers/gate.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import logging
+from telebot import types
+from bot import bot
+from services.settings import is_authorized, get_roles, log_rejected
+
+log = logging.getLogger("access")
+
+@bot.message_handler(func=lambda m: not is_authorized(m.from_user.id), content_types=['text','photo','audio','document','sticker','video','voice','location','contact'])
+def gate_message(message: types.Message):
+    cmd = message.text or ''
+    log_rejected(message.from_user.id, cmd, 'not_allowed')
+    # Ничего не отвечаем — сообщение игнорируется
+    return

--- a/handlers/setup/router.py
+++ b/handlers/setup/router.py
@@ -44,11 +44,34 @@ def render_templates_home(chat_id: int) -> None:
     kb.add(types.InlineKeyboardButton("Настроить соответствие цветов", callback_data="setup:tmpl_map"))
     kb.add(types.InlineKeyboardButton("Настроить количество", callback_data="setup:tmpl_qty"))
     kb.add(types.InlineKeyboardButton("Загрузить изображения с макетами", callback_data="setup:tmpl_collages"))
+    kb.add(types.InlineKeyboardButton("Структура доступности", callback_data="setup:tmpl_structure"))
     kb.add(types.InlineKeyboardButton("Ограничение макетов на заказ", callback_data="setup:tmpl_limit"))
     kb.add(types.InlineKeyboardButton("Смайлик выбранного макета", callback_data="setup:tmpl_indicator"))
     kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:home"))
     edit(chat_id, "🧩 Шаг 3/4 — Макеты\n" + "\n".join(lines), kb)
     WIZ[chat_id]["stage"] = "tmpls_home"
+
+
+def render_availability_structure(chat_id: int) -> None:
+    data = WIZ[chat_id]["data"]
+    merch = data.get("merch", {})
+    templates = data.get("templates", {})
+    lines = ["Мерч"]
+    for mk, mi in merch.items():
+        lines.append(f"  • {mi['name_ru']}")
+        colors = mi.get("colors", {})
+        tmpl_for_merch = templates.get(mk, {}).get("templates", {})
+        for ck, ci in colors.items():
+            layouts = [
+                num for num, info in tmpl_for_merch.items()
+                if ck in info.get('allowed_colors', [])
+            ]
+            layout_str = ", ".join(sorted(layouts, key=str)) if layouts else "—"
+            lines.append(f"    — {ci['name_ru']}  — макеты: {layout_str}")
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="setup:tmpls"))
+    edit(chat_id, "<pre>" + "\n".join(lines) + "</pre>", kb)
+    WIZ[chat_id]["stage"] = "tmpls_structure"
 
 @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("setup:"))
 def setup_router(c: types.CallbackQuery):
@@ -122,6 +145,7 @@ def setup_router(c: types.CallbackQuery):
     if cmd == "tmpl_qty":              INV.open_inventory_templates(chat_id); return
     if cmd == "tmpl_collages":         TCOLL.ask_collages_or_next(chat_id); return
     if cmd == "tmpl_collages_done":    render_templates_home(chat_id); return
+    if cmd == "tmpl_structure":        render_availability_structure(chat_id); return
     if cmd == "tmpl_limit":
         cur = WIZ[chat_id]["data"].setdefault("layouts", get_settings().get("layouts", {})).get("max_per_order", 3)
         kb = types.InlineKeyboardMarkup()

--- a/main.py
+++ b/main.py
@@ -3,11 +3,13 @@ import time, logging
 from requests.exceptions import ReadTimeout, ConnectionError
 from bot import bot
 from router import register_routes
+from services.settings import refresh_promo_cache
 
 log = logging.getLogger("runner")
 
 def run_bot() -> None:
     register_routes()
+    refresh_promo_cache(bot)
     while True:
         try:
             bot.infinity_polling(

--- a/router.py
+++ b/router.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
+# gate должен импортироваться первым, чтобы отсеивать неавторизованных
+from handlers import gate  # noqa: F401
 from handlers import start, bind, order_flow, settings, errors, debug, commands  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes

--- a/services/settings.py
+++ b/services/settings.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Set
+import logging
 from repositories.files import load_json, save_json
 
 SETTINGS_FILE = "settings.json"
 ADMIN_BIND_FILE = "admin_chat.json"
 
-SUPERADMINS = [445075408]
+# Нельзя удалить или изменить этого супер-админа
+SUPERADMINS: Set[int] = {445075408}
+
+# Кэш участников промо-группы (пополняется при запуске и через /promo_refresh)
+PROMO_CACHE: Set[int] = set()
+log = logging.getLogger("access")
 
 def get_settings() -> Dict[str, Any]:
     data = load_json(SETTINGS_FILE)
@@ -28,12 +34,16 @@ def get_settings() -> Dict[str, Any]:
                 "max_per_order": 3,
                 "selected_indicator": "🟩"
             },
-            "admins": []
+            "admins": [],
+            "coordinators": [],
+            "group_chat_id": None
         }
     else:
         data.setdefault("color_names", {})
         data.setdefault("layouts", {})
         data.setdefault("admins", [])
+        data.setdefault("coordinators", [])
+        data.setdefault("group_chat_id", None)
         data["layouts"].setdefault("max_per_order", 3)
         data["layouts"].setdefault("selected_indicator", "🟩")
     return data
@@ -51,6 +61,26 @@ def save_admin_bind(chat_id, thread_id=None) -> None:
 
 def get_admins() -> List[int]:
     return get_settings().get("admins", [])
+
+
+def get_coordinators() -> List[int]:
+    return get_settings().get("coordinators", [])
+
+
+def add_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id not in coords:
+        coords.append(user_id)
+        save_settings(data)
+
+
+def del_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id in coords:
+        coords.remove(user_id)
+        save_settings(data)
 
 
 def add_admin(user_id: int) -> None:
@@ -75,3 +105,57 @@ def is_superadmin(user_id: int) -> bool:
 
 def is_admin(user_id: int) -> bool:
     return user_id in SUPERADMINS or user_id in get_admins()
+
+
+def is_coordinator(user_id: int) -> bool:
+    return user_id in get_coordinators()
+
+
+def get_group_chat_id() -> int | None:
+    return get_settings().get("group_chat_id")
+
+
+def set_group_chat_id(chat_id: int) -> None:
+    data = get_settings()
+    data["group_chat_id"] = chat_id
+    save_settings(data)
+
+
+def refresh_promo_cache(bot=None) -> None:
+    """Rescan group chat members and refresh PROMO cache."""
+    global PROMO_CACHE
+    PROMO_CACHE = set()
+    gid = get_group_chat_id()
+    if not bot or not gid:
+        return
+    try:
+        members = bot.get_chat_administrators(gid)
+        PROMO_CACHE.update(m.user.id for m in members)
+    except Exception as e:
+        log.warning("promo_refresh failed: %s", e)
+
+
+def is_promo(user_id: int) -> bool:
+    return user_id in PROMO_CACHE
+
+
+def get_roles(user_id: int) -> List[str]:
+    roles: List[str] = []
+    if is_superadmin(user_id):
+        roles.append("SUPERADMIN")
+    if user_id in get_admins():
+        roles.append("ADMIN")
+    if is_coordinator(user_id):
+        roles.append("COORDINATOR")
+    if is_promo(user_id):
+        roles.append("PROMO")
+    return roles
+
+
+def is_authorized(user_id: int) -> bool:
+    return bool(get_roles(user_id))
+
+
+def log_rejected(user_id: int, command: str, reason: str) -> None:
+    roles = get_roles(user_id)
+    log.info("rejected command: %s", {"user_id": user_id, "roles": roles, "command": command, "reason": reason})


### PR DESCRIPTION
## Summary
- add SUPERADMIN/ADMIN/COORDINATOR/PROMO role management with persistent settings
- gate unauthorized users and add coordinator & promo admin commands
- refresh promo cache at startup and expose /whoami diagnostics
- render availability structure tree in setup wizard with back navigation

## Testing
- `python -m py_compile services/settings.py handlers/gate.py router.py handlers/commands.py main.py`
- `python -m py_compile handlers/setup/router.py`


------
https://chatgpt.com/codex/tasks/task_e_689b9a94a224832496206d905f7a60f6