### PR TITLE
Add admin self-registration and access control

### DIFF
--- a/handlers/access.py
+++ b/handlers/access.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from telebot import types
+from bot import bot
+from services.settings import (
+    get_admins,
+    get_coordinators,
+    is_admin,
+    get_admin_bind,
+)
+
+
+def _is_general_member(user_id: int) -> bool:
+    chat_id, _ = get_admin_bind()
+    if not chat_id:
+        return False
+    try:
+        member = bot.get_chat_member(chat_id, user_id)
+        return member.status in ("creator", "administrator", "member")
+    except Exception:
+        return False
+
+
+def is_allowed(user_id: int) -> bool:
+    if not get_admins():
+        # until an admin is added, allow everyone
+        return True
+    if is_admin(user_id):
+        return True
+    if user_id in get_coordinators():
+        return True
+    if _is_general_member(user_id):
+        return True
+    return False
+
+
+@bot.message_handler(func=lambda m: not is_allowed(m.from_user.id))
+def block_users(m: types.Message):
+    bot.reply_to(m, "⛔️ Доступ запрещён")
+
+
+@bot.callback_query_handler(func=lambda c: not is_allowed(c.from_user.id))
+def block_callbacks(c: types.CallbackQuery):
+    bot.answer_callback_query(c.id, "Доступ запрещён", show_alert=True)
+

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -8,6 +8,9 @@ from services.settings import (
     del_admin,
     get_admins,
     SUPERADMINS,
+    add_coordinator,
+    del_coordinator,
+    get_coordinators,
 )
 
 
@@ -58,6 +61,10 @@ def cmd_settings(message: types.Message):
 
 @bot.message_handler(commands=["admin"])
 def cmd_admin(message: types.Message):
+    if not get_admins():
+        add_admin(message.from_user.id)
+        bot.reply_to(message, "✅ Вы назначены главным администратором")
+        return
     if not _require_admin(message):
         return
     bot.send_message(message.chat.id, "Админка в разработке.")
@@ -65,8 +72,7 @@ def cmd_admin(message: types.Message):
 
 @bot.message_handler(commands=["admin_add"])
 def cmd_admin_add(message: types.Message):
-    if not is_superadmin(message.from_user.id):
-        bot.reply_to(message, "❌ Недостаточно прав")
+    if not _require_admin(message):
         return
     uid = _extract_uid(message)
     if uid is None:
@@ -78,8 +84,7 @@ def cmd_admin_add(message: types.Message):
 
 @bot.message_handler(commands=["admin_del"])
 def cmd_admin_del(message: types.Message):
-    if not is_superadmin(message.from_user.id):
-        bot.reply_to(message, "❌ Недостаточно прав")
+    if not _require_admin(message):
         return
     uid = _extract_uid(message)
     if uid is None:
@@ -91,12 +96,43 @@ def cmd_admin_del(message: types.Message):
 
 @bot.message_handler(commands=["admin_list"])
 def cmd_admin_list(message: types.Message):
-    if not is_superadmin(message.from_user.id):
-        bot.reply_to(message, "❌ Недостаточно прав")
+    if not _require_admin(message):
         return
     admins = ", ".join(map(str, get_admins())) or "—"
-    supers = ", ".join(map(str, SUPERADMINS))
+    supers = ", ".join(map(str, SUPERADMINS)) or "—"
     bot.reply_to(message, f"SUPERADMINS: {supers}\nADMINS: {admins}")
+
+
+@bot.message_handler(commands=["coord_add"])
+def cmd_coord_add(message: types.Message):
+    if not _require_admin(message):
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    add_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} добавлен в координаторы")
+
+
+@bot.message_handler(commands=["coord_del"])
+def cmd_coord_del(message: types.Message):
+    if not _require_admin(message):
+        return
+    uid = _extract_uid(message)
+    if uid is None:
+        bot.reply_to(message, "Укажите user_id")
+        return
+    del_coordinator(uid)
+    bot.reply_to(message, f"✅ Пользователь {uid} удалён из координаторов")
+
+
+@bot.message_handler(commands=["coord_list"])
+def cmd_coord_list(message: types.Message):
+    if not _require_admin(message):
+        return
+    coords = ", ".join(map(str, get_coordinators())) or "—"
+    bot.reply_to(message, f"Координаторы: {coords}")
 
 
 @bot.message_handler(func=lambda m: m.text and m.text.startswith("/"))

--- a/router.py
+++ b/router.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Регистрация всех хэндлеров (импорты регистрируют декораторы)
-from handlers import start, bind, order_flow, settings, errors, debug, commands  # noqa: F401
+from handlers import access, start, bind, order_flow, settings, errors, debug, commands  # noqa: F401
 from bot import bot  # если уже есть — оставьте как было            # noqa: F401
 from modules.router import register_module_routes
 

--- a/services/settings.py
+++ b/services/settings.py
@@ -5,7 +5,7 @@ from repositories.files import load_json, save_json
 SETTINGS_FILE = "settings.json"
 ADMIN_BIND_FILE = "admin_chat.json"
 
-SUPERADMINS = [445075408]
+SUPERADMINS: List[int] = []
 
 def get_settings() -> Dict[str, Any]:
     data = load_json(SETTINGS_FILE)
@@ -28,12 +28,14 @@ def get_settings() -> Dict[str, Any]:
                 "max_per_order": 3,
                 "selected_indicator": "🟩"
             },
-            "admins": []
+            "admins": [],
+            "coordinators": []
         }
     else:
         data.setdefault("color_names", {})
         data.setdefault("layouts", {})
         data.setdefault("admins", [])
+        data.setdefault("coordinators", [])
         data["layouts"].setdefault("max_per_order", 3)
         data["layouts"].setdefault("selected_indicator", "🟩")
     return data
@@ -75,3 +77,23 @@ def is_superadmin(user_id: int) -> bool:
 
 def is_admin(user_id: int) -> bool:
     return user_id in SUPERADMINS or user_id in get_admins()
+
+
+def get_coordinators() -> List[int]:
+    return get_settings().get("coordinators", [])
+
+
+def add_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id not in coords:
+        coords.append(user_id)
+        save_settings(data)
+
+
+def del_coordinator(user_id: int) -> None:
+    data = get_settings()
+    coords = data.setdefault("coordinators", [])
+    if user_id in coords:
+        coords.remove(user_id)
+        save_settings(data)


### PR DESCRIPTION
## Summary
- allow first user to promote themselves to admin via /admin
- block unauthorized users and let admins manage coordinators

## Testing
- `python -m py_compile services/settings.py handlers/access.py handlers/commands.py router.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb9f43d308324863a27319bd4b110